### PR TITLE
Add demo user seed and wire users page to GET /users

### DIFF
--- a/backend/infrastructure/postgres/core/04-seed-users.sql
+++ b/backend/infrastructure/postgres/core/04-seed-users.sql
@@ -1,0 +1,26 @@
+-- ============================================
+-- 20 SAMPLE USERS SEED
+-- ============================================
+
+INSERT INTO users (id, username, role, status) VALUES
+  (1, 'demo_chef', 'user', 'offline'),
+  (2, 'anna_kitchen', 'user', 'online'),
+  (3, 'mika_soup', 'user', 'offline'),
+  (4, 'ella_bakes', 'user', 'online'),
+  (5, 'noah_grills', 'user', 'offline'),
+  (6, 'sofia_salads', 'user', 'online'),
+  (7, 'liam_pasta', 'user', 'offline'),
+  (8, 'olivia_spice', 'user', 'online'),
+  (9, 'leo_breakfast', 'user', 'offline'),
+  (10, 'mila_vegan', 'user', 'online'),
+  (11, 'emil_smokehouse', 'user', 'offline'),
+  (12, 'sara_sweets', 'user', 'online'),
+  (13, 'otto_oven', 'user', 'offline'),
+  (14, 'nora_nordic', 'user', 'online'),
+  (15, 'toni_tacos', 'user', 'offline'),
+  (16, 'ida_herbs', 'user', 'online'),
+  (17, 'aleksi_wok', 'user', 'offline'),
+  (18, 'venla_simmer', 'user', 'online'),
+  (19, 'joel_brunch', 'user', 'offline'),
+  (20, 'aino_homecook', 'user', 'online')
+ON CONFLICT (id) DO NOTHING;

--- a/frontend/app/components/UsersGrid.tsx
+++ b/frontend/app/components/UsersGrid.tsx
@@ -1,14 +1,18 @@
 import { UserCard } from "./cards/UserCard";
 import "../assets/styles/usersGrid.css";
+import { useEffect, useState } from "react";
 
 type UserCardResponse = {
 	id: number;
-	name: string;
-	recipeCount: number;
+	username: string;
+	recipes_count: number;
 };
 
 type UsersGridProps = {
 	sortValue?: string;
+	onLoad?: (totalCount: number) => void;
+	page?: number;
+	perPage?: number;
 };
 
 const sortUsers = (
@@ -16,37 +20,51 @@ const sortUsers = (
 	sortValue: string,
 ): UserCardResponse[] => {
 	const sorted = [...users];
+
 	switch (sortValue) {
 		case "name-asc":
-			return sorted.sort((a, b) => a.name.localeCompare(b.name));
+			return sorted.sort((a, b) => a.username.localeCompare(b.username));
 		case "name-desc":
-			return sorted.sort((a, b) => b.name.localeCompare(a.name));
+			return sorted.sort((a, b) => b.username.localeCompare(a.username));
 		case "recipes-asc":
-			return sorted.sort((a, b) => a.recipeCount - b.recipeCount);
+			return sorted.sort((a, b) => a.recipes_count - b.recipes_count);
 		case "recipes-desc":
-			return sorted.sort((a, b) => b.recipeCount - a.recipeCount);
+			return sorted.sort((a, b) => b.recipes_count - a.recipes_count);
 		default:
 			return sorted;
 	}
 };
 
-export const UsersGrid = ({ sortValue = "name-asc" }: UsersGridProps) => {
-	// TODO: replace mock data with backend users when endpoint is available
-	const userList: UserCardResponse[] = [
-		{ id: 1, name: "John", recipeCount: 12 },
-		{ id: 2, name: "Emma", recipeCount: 8 },
-		{ id: 3, name: "Liam", recipeCount: 15 },
-		{ id: 4, name: "Olivia", recipeCount: 5 },
-		{ id: 5, name: "Noah", recipeCount: 20 },
-	];
+export const UsersGrid = ({
+	onLoad,
+	sortValue = "name-asc",
+}: UsersGridProps) => {
+	const [userList, setUserList] = useState<UserCardResponse[]>([]);
+
+	useEffect(() => {
+		fetch("http://localhost:3000/users")
+			.then((res) => {
+				if (!res.ok) {
+					console.log("The user database is empty.");
+					return { data: [] };
+				}
+				return res.json();
+			})
+			.then((body) => {
+				const allUsers: UserCardResponse[] = body.data ?? [];
+				onLoad?.(allUsers.length);
+				setUserList(allUsers);
+			})
+			.catch(console.error);
+	}, [onLoad]);
 
 	const sorted = sortUsers(userList, sortValue);
 
 	return (
 		<ul className="user-card-list">
-			{sorted.map(({ id, name, recipeCount }) => (
+			{sorted.map(({ id, username, recipes_count }) => (
 				<li key={id}>
-					<UserCard id={id} name={name} recipeCount={recipeCount} />
+					<UserCard id={id} name={username} recipeCount={recipes_count} />
 				</li>
 			))}
 		</ul>

--- a/frontend/app/routes/users.tsx
+++ b/frontend/app/routes/users.tsx
@@ -14,6 +14,7 @@ import { useSortParam } from "~/composables/useSortParam";
 const UsersPage = () => {
 	const { t } = useTranslation();
 	const [activeFilterIndex, setActiveFilterIndex] = useState(0);
+	const [totalCount, setTotalCount] = useState(0);
 	const sortOptions = useSortOptions("users");
 	const [sortValue, setSort] = useSortParam(sortOptions[0].value);
 
@@ -27,7 +28,7 @@ const UsersPage = () => {
 		<section className="users-page">
 			<PageHeader
 				title={t("usersPage.title")}
-				totalLabel={`${t("usersPage.totalCount")} 37`}
+				totalLabel={`${t("usersPage.totalCount")} ${totalCount}`}
 			/>
 
 			<SearchField placeholder={t("common.searchPlaceholder")} />
@@ -49,7 +50,7 @@ const UsersPage = () => {
 				</TextIconButton>
 			</div>
 
-			<UsersGrid sortValue={sortValue} />
+			<UsersGrid sortValue={sortValue} onLoad={setTotalCount} />
 		</section>
 	);
 };


### PR DESCRIPTION
Changes:
- add 04-seed-users.sql with 20 demo users
- connect users page to GET /users
- update frontend match backend fields (username, recipes_count)
- replace the hardcoded users total (37) with the real count returned from the backend

testing:
seeded users into core_db with:
```
sudo docker exec -i core-postgres psql -U core_user -d core_db < backend/infrastructure/postgres/core/04-seed-users.sql
```

next:
- will add pagination to users page in a separate PR
- cooks row currently uses mock data and will connect it to backend in a follow-up PR

close #162 