### PR TITLE
hotfix

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,6 +4,11 @@
 # Common
 NODE_ENV="development"
 
+# Traefik Docker provider socket (important for rootless Docker)
+# Rootful Docker default: /var/run/docker.sock
+# Rootless Docker example: /run/user/1000/docker.sock
+DOCKER_SOCKET_PATH="/var/run/docker.sock"
+
 # CORS - frontend origin allowed to make requests to the API
 # In production, set to your frontend URL: https://yourdomain.com
 CORS_ORIGIN="http://localhost:5173"

--- a/backend/services/auth-service/tests/test-auth.sh
+++ b/backend/services/auth-service/tests/test-auth.sh
@@ -5,7 +5,7 @@
 # Auth Endpoint Test Script
 # Tests all auth endpoints with valid, invalid, and edge cases
 
-BASE_URL="https://localhost/auth"
+BASE_URL="https://localhost:8443/auth"
 PASS=0
 FAIL=0
 

--- a/backend/services/auth-service/tests/test-auth2.sh
+++ b/backend/services/auth-service/tests/test-auth2.sh
@@ -7,7 +7,7 @@
 #This token will need refreshing periodically. https://developers.google.com/oauthplayground
 GOOGLE_ID_TOKEN="insert token"
 
-BASE_URL="https://localhost/auth"
+BASE_URL="https://localhost:8443/auth"
 
 echo "=========================================="
 echo "Complete Auth Test Suite"

--- a/backend/services/auth-service/tests/test-goog.sh
+++ b/backend/services/auth-service/tests/test-goog.sh
@@ -2,7 +2,7 @@
 
 GOOGLE_ID_TOKEN="replace with ID"
 
-BASE_URL="https://localhost/auth"
+BASE_URL="https://localhost:8443/auth"
 
 echo "=========================================="
 echo "Google Auth Complete Flow Test Suite"

--- a/backend/services/auth-service/tests/test-goog2.sh
+++ b/backend/services/auth-service/tests/test-goog2.sh
@@ -2,7 +2,7 @@
 
 GOOGLE_ID_TOKEN="replace wiht ID"
 
-BASE_URL="https://localhost/auth"
+BASE_URL="https://localhost:8443/auth"
 
 echo "=========================================="
 echo "Test: Google User Tries Normal Login"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "8443:443"
 
     volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "${DOCKER_SOCKET_PATH:-/var/run/docker.sock}:/var/run/docker.sock:ro"
       - "./traefik/traefik.yml:/traefik/traefik.yml:ro"
       - "./traefik/dynamic.yml:/traefik/dynamic.yml:ro"
       - "./certs:/certs:ro"
@@ -94,9 +94,10 @@ services:
 
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.gateway-https.rule=Host(`localhost`)"
+      - "traefik.http.routers.gateway-https.rule=Host(`localhost`) || Host(`127.0.0.1`)"
       - "traefik.http.routers.gateway-https.entrypoints=websecure"
       - "traefik.http.routers.gateway-https.tls=true"
+      - "traefik.http.routers.gateway-https.service=gateway"
       - "traefik.http.services.gateway.loadbalancer.server.port=3000"
 
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,6 @@ services:
     environment:
       NODE_ENV: development
       PORT: 3000
-      CORS_ORIGIN: "http://localhost:5173/"
       AUTH_SERVICE_URL: http://auth-service:3001
       CORE_SERVICE_URL: http://core-service:3002
       NOTIFICATION_SERVICE_URL: http://notification-service:3003
@@ -138,7 +137,6 @@ services:
     environment:
       NODE_ENV: development
       PORT: 3002
-      CORS_ORIGIN: "http://localhost:5173/"
       DATABASE_URL: postgresql://core_user:core_password@core-db:5432/core_db
 
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     environment:
       NODE_ENV: development
       PORT: 3000
-      CORS_ORIGIN: "http://localhost:5173"
+      CORS_ORIGIN: "http://localhost:5173/"
       AUTH_SERVICE_URL: http://auth-service:3001
       CORE_SERVICE_URL: http://core-service:3002
       NOTIFICATION_SERVICE_URL: http://notification-service:3003
@@ -138,7 +138,7 @@ services:
     environment:
       NODE_ENV: development
       PORT: 3002
-      CORS_ORIGIN: "http://localhost:5173"
+      CORS_ORIGIN: "http://localhost:5173/"
       DATABASE_URL: postgresql://core_user:core_password@core-db:5432/core_db
 
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,7 @@ services:
     environment:
       NODE_ENV: development
       PORT: 3000
+      CORS_ORIGIN: "http://localhost:5173"
       AUTH_SERVICE_URL: http://auth-service:3001
       CORE_SERVICE_URL: http://core-service:3002
       NOTIFICATION_SERVICE_URL: http://notification-service:3003
@@ -137,6 +138,7 @@ services:
     environment:
       NODE_ENV: development
       PORT: 3002
+      CORS_ORIGIN: "http://localhost:5173"
       DATABASE_URL: postgresql://core_user:core_password@core-db:5432/core_db
 
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - "--configFile=/traefik/traefik.yml"
 
     ports:
-      - "80:80"
-      - "443:443"
+      - "8080:80"
+      - "8443:443"
 
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"

--- a/frontend/app/composables/apiBaseUrl.ts
+++ b/frontend/app/composables/apiBaseUrl.ts
@@ -1,3 +1,3 @@
 // Read the API base URL from Vite env, falling back to localhost for local development.
 export const API_BASE_URL =
-	import.meta.env.VITE_API_BASE_URL ?? "https://localhost";
+	import.meta.env.VITE_API_BASE_URL ?? "https://localhost:8443";

--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -4,6 +4,7 @@ set -e
 
 if [ -f "certs/cert.pem" ] && [ -f "certs/key.pem" ]; then
     echo "Certificates already exist, skipping generation"
+    echo "Note: if you need to regenerate, run: rm -rf certs/ && make certs"
     exit 0
 fi
 
@@ -19,3 +20,11 @@ openssl req -x509 -newkey rsa:4096 \
     -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
 
 echo "✓ Certificates generated successfully"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "Trusting certificate in macOS keychain..."
+    security add-trusted-cert -d -r trustRoot \
+        -k ~/Library/Keychains/login.keychain \
+        certs/cert.pem
+    echo "✓ Certificate trusted — restart your browser to apply"
+fi

--- a/test-endpoints.sh
+++ b/test-endpoints.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-BASE_URL="${API_BASE_URL:-https://localhost}"
+BASE_URL="${API_BASE_URL:-https://localhost:8443}"
 SMOKE_BEARER_TOKEN="${SMOKE_BEARER_TOKEN:-}"
 FAIL=0
 TESTS_PASSED=0


### PR DESCRIPTION
Hotfix for ports 8443 and 8080 instead of 443 and 80 (for Hive macs)

When working on school macs, please modify .env file variable DOCKER_SOCKET_PATH for rootless run:

# Rootful Docker default: /var/run/docker.sock
# Rootless Docker example: /run/user/1000/docker.sock
DOCKER_SOCKET_PATH="/var/run/docker.sock"