### PR TITLE
add frontend Google login flow

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,2 @@
-VITE_API_BASE_URL=http://localhost:3000
+VITE_API_BASE_URL=https://localhost:8443
+VITE_GOOGLE_CLIENT_ID=

--- a/frontend/app/assets/styles/auth.css
+++ b/frontend/app/assets/styles/auth.css
@@ -21,21 +21,41 @@
 	background-color: var(--surface-card);
 	border: 1px solid var(--borders-action);
 	color: var(--text-primary);
-}
-
-.auth-social-button-content {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: var(--space-s);
 	width: 100%;
+	pointer-events: none;
 }
 
 .auth-social-google {
-	display: inline-flex;
+	stroke-width: 1;
+}
+
+.auth-google-button-shell {
+	position: relative;
+	display: flex;
+	justify-content: center;
+	width: 100%;
+}
+
+.auth-google-render-target {
+	position: absolute;
+	inset: 0;
+	z-index: 2;
+	display: flex;
 	align-items: center;
 	justify-content: center;
-	stroke-width: 1;
+	width: 100%;
+	opacity: 0;
+}
+
+.auth-google-render-target[aria-hidden="true"] {
+	visibility: hidden;
+	pointer-events: none;
+}
+
+.auth-google-render-target > *,
+.auth-google-render-target iframe {
+	width: 100%;
+	height: 100%;
 }
 
 .auth-form {
@@ -73,7 +93,6 @@
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
-	gap: var(--space-xs);
 }
 
 .auth-modal-close-row {

--- a/frontend/app/assets/styles/auth.css
+++ b/frontend/app/assets/styles/auth.css
@@ -21,6 +21,9 @@
 	background-color: var(--surface-card);
 	border: 1px solid var(--borders-action);
 	color: var(--text-primary);
+	height: auto;
+	min-height: 44px;
+	white-space: normal;
 	width: 100%;
 	pointer-events: none;
 }

--- a/frontend/app/assets/styles/auth.css
+++ b/frontend/app/assets/styles/auth.css
@@ -28,6 +28,10 @@
 	pointer-events: none;
 }
 
+.main-button.inverted.auth-social-button[data-google-ready="true"]:disabled {
+	opacity: 1;
+}
+
 .auth-social-google {
 	stroke-width: 1;
 }

--- a/frontend/app/components/RecipesGrid.tsx
+++ b/frontend/app/components/RecipesGrid.tsx
@@ -13,7 +13,7 @@ type RecipeCardResponse = {
 };
 
 type RecipesGridProps = {
-	sortValue?: string;
+	sortValue: string;
 	page?: number;
 	perPage?: number;
 	onLoad?: (totalCount: number) => void;
@@ -44,7 +44,7 @@ export const RecipesGrid = ({
 	perPage = 12,
 	onLoad,
 	sort,
-	sortValue = "",
+	sortValue,
 }: RecipesGridProps) => {
 	const { t } = useTranslation();
 	const [recipeList, setRecipeList] = useState<RecipeCardResponse[]>([]);

--- a/frontend/app/components/RecipesGrid.tsx
+++ b/frontend/app/components/RecipesGrid.tsx
@@ -13,7 +13,7 @@ type RecipeCardResponse = {
 };
 
 type RecipesGridProps = {
-	sortValue: string;
+	sortValue?: string;
 	page?: number;
 	perPage?: number;
 	onLoad?: (totalCount: number) => void;
@@ -44,7 +44,7 @@ export const RecipesGrid = ({
 	perPage = 12,
 	onLoad,
 	sort,
-	sortValue,
+	sortValue = "",
 }: RecipesGridProps) => {
 	const { t } = useTranslation();
 	const [recipeList, setRecipeList] = useState<RecipeCardResponse[]>([]);

--- a/frontend/app/components/auth/AuthForm.tsx
+++ b/frontend/app/components/auth/AuthForm.tsx
@@ -73,6 +73,15 @@ const loadGoogleIdentityScript = () =>
 			`script[src="${GOOGLE_IDENTITY_SCRIPT_SRC}"]`,
 		);
 		if (existingScript) {
+			const status = existingScript.dataset.gsiStatus;
+			if (status === "loaded") {
+				resolve();
+				return;
+			}
+			if (status === "error") {
+				reject(new Error("Google Identity Services failed to load"));
+				return;
+			}
 			existingScript.addEventListener("load", () => resolve(), { once: true });
 			existingScript.addEventListener(
 				"error",
@@ -86,9 +95,15 @@ const loadGoogleIdentityScript = () =>
 		script.src = GOOGLE_IDENTITY_SCRIPT_SRC;
 		script.async = true;
 		script.defer = true;
-		script.onload = () => resolve();
-		script.onerror = () =>
+		script.dataset.gsiStatus = "loading";
+		script.onload = () => {
+			script.dataset.gsiStatus = "loaded";
+			resolve();
+		};
+		script.onerror = () => {
+			script.dataset.gsiStatus = "error";
 			reject(new Error("Google Identity Services failed to load"));
+		};
 		document.head.appendChild(script);
 	});
 

--- a/frontend/app/components/auth/AuthForm.tsx
+++ b/frontend/app/components/auth/AuthForm.tsx
@@ -1,6 +1,14 @@
 import { Google, Xmark } from "iconoir-react";
-import { type RefObject, useState } from "react";
+import {
+	type FormEvent,
+	type RefObject,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
 import { useTranslation } from "react-i18next";
+import { z } from "zod";
 import { IconButton } from "~/components/buttons/IconButton";
 import { MainButton } from "~/components/buttons/MainButton";
 import { TextIconButton } from "~/components/buttons/TextIconButton";
@@ -10,11 +18,85 @@ import "~/assets/styles/auth.css";
 
 type AuthMode = "login" | "signup";
 
+type GoogleCredentialResponse = {
+	credential?: string;
+};
+
+declare global {
+	interface Window {
+		google?: {
+			accounts: {
+				id: {
+					initialize: (config: {
+						client_id: string;
+						callback: (response: GoogleCredentialResponse) => void;
+					}) => void;
+					renderButton: (
+						parent: HTMLElement,
+						options: {
+							theme: "outline";
+							size: "large";
+							text: "signin_with" | "signup_with";
+							width: number;
+						},
+					) => void;
+				};
+			};
+		};
+	}
+}
+
 type AuthFormProps = {
 	initialMode?: AuthMode;
 	dialogRef?: RefObject<HTMLElement | null>;
 	onClose?: () => void;
 	onSuccess?: () => void;
+};
+
+const GOOGLE_IDENTITY_SCRIPT_SRC = "https://accounts.google.com/gsi/client";
+const GOOGLE_BUTTON_MIN_WIDTH = 240;
+const GOOGLE_CLIENT_ID_PLACEHOLDER =
+	"123456789012-abc123def456gh789ijklmn0pqrstuvw.apps.googleusercontent.com";
+
+const AuthErrorResponseSchema = z.object({
+	error: z.string().optional(),
+});
+
+const loadGoogleIdentityScript = () =>
+	new Promise<void>((resolve, reject) => {
+		if (window.google?.accounts?.id) {
+			resolve();
+			return;
+		}
+
+		const existingScript = document.querySelector<HTMLScriptElement>(
+			`script[src="${GOOGLE_IDENTITY_SCRIPT_SRC}"]`,
+		);
+		if (existingScript) {
+			existingScript.addEventListener("load", () => resolve(), { once: true });
+			existingScript.addEventListener(
+				"error",
+				() => reject(new Error("Google Identity Services failed to load")),
+				{ once: true },
+			);
+			return;
+		}
+
+		const script = document.createElement("script");
+		script.src = GOOGLE_IDENTITY_SCRIPT_SRC;
+		script.async = true;
+		script.defer = true;
+		script.onload = () => resolve();
+		script.onerror = () =>
+			reject(new Error("Google Identity Services failed to load"));
+		document.head.appendChild(script);
+	});
+
+const readAuthError = async (response: Response) => {
+	const body: unknown = await response.json().catch(() => null);
+	const parsed = AuthErrorResponseSchema.safeParse(body);
+
+	return parsed.success ? parsed.data.error : undefined;
 };
 
 export const AuthForm = ({
@@ -24,14 +106,113 @@ export const AuthForm = ({
 	onSuccess,
 }: AuthFormProps) => {
 	const { t } = useTranslation();
+	const googleButtonRef = useRef<HTMLDivElement | null>(null);
+	const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+	const googleMissingClientId =
+		!googleClientId || googleClientId === GOOGLE_CLIENT_ID_PLACEHOLDER;
 	const [mode, setMode] = useState<AuthMode>(initialMode);
 	const [email, setEmail] = useState("");
 	const [password, setPassword] = useState("");
 	const [error, setError] = useState("");
 	const [message, setMessage] = useState("");
 	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [isGoogleReady, setIsGoogleReady] = useState(false);
+	const [isGoogleSubmitting, setIsGoogleSubmitting] = useState(false);
 
-	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+	const handleGoogleCredential = useCallback(
+		async (googleResponse: GoogleCredentialResponse) => {
+			setError("");
+			setMessage("");
+
+			if (!googleResponse.credential) {
+				setError(t("authModal.googleTokenError"));
+				return;
+			}
+
+			setIsGoogleSubmitting(true);
+
+			try {
+				const response = await fetch(`${API_BASE_URL}/auth/google`, {
+					method: "POST",
+					headers: {
+						Authorization: `Bearer ${googleResponse.credential}`,
+					},
+					credentials: "include",
+				});
+
+				const authError = await readAuthError(response);
+
+				if (!response.ok) {
+					setError(authError ?? t("authModal.genericError"));
+					return;
+				}
+
+				setEmail("");
+				setPassword("");
+				setMessage(t("authModal.loginSuccess"));
+				onSuccess?.();
+			} catch (googleError) {
+				console.error(googleError);
+				setError(
+					googleError instanceof TypeError
+						? t("authModal.networkError")
+						: t("authModal.genericError"),
+				);
+			} finally {
+				setIsGoogleSubmitting(false);
+			}
+		},
+		[onSuccess, t],
+	);
+
+	useEffect(() => {
+		const buttonContainer = googleButtonRef.current;
+		if (!buttonContainer || googleMissingClientId) {
+			setIsGoogleReady(false);
+			return;
+		}
+
+		let isCurrent = true;
+		buttonContainer.replaceChildren();
+		setIsGoogleReady(false);
+
+		loadGoogleIdentityScript()
+			.then(() => {
+				if (!isCurrent || !window.google?.accounts?.id) {
+					return;
+				}
+
+				window.google.accounts.id.initialize({
+					client_id: googleClientId,
+					callback: handleGoogleCredential,
+				});
+				buttonContainer.replaceChildren();
+				const buttonWidth = Math.max(
+					GOOGLE_BUTTON_MIN_WIDTH,
+					Math.floor(buttonContainer.clientWidth),
+				);
+				window.google.accounts.id.renderButton(buttonContainer, {
+					theme: "outline",
+					size: "large",
+					text: mode === "login" ? "signin_with" : "signup_with",
+					width: buttonWidth,
+				});
+				setIsGoogleReady(true);
+			})
+			.catch((scriptError) => {
+				console.error(scriptError);
+				if (isCurrent) {
+					setError(t("authModal.googleUnavailable"));
+				}
+			});
+
+		return () => {
+			isCurrent = false;
+			buttonContainer.replaceChildren();
+		};
+	}, [googleMissingClientId, handleGoogleCredential, mode, t]);
+
+	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
 		setError("");
 		setMessage("");
@@ -52,29 +233,29 @@ export const AuthForm = ({
 				body: JSON.stringify(payload),
 			});
 
-			const data = (await response.json()) as { error?: string };
+			const authError = await readAuthError(response);
 
 			if (!response.ok) {
-				setError(data.error ?? t("loginPage.genericError"));
+				setError(authError ?? t("authModal.genericError"));
 				return;
 			}
 
 			if (mode === "signup") {
 				setPassword("");
-				setMessage(t("loginPage.signupSuccess"));
+				setMessage(t("authModal.signupSuccess"));
 				onSuccess?.();
 				return;
 			}
 
 			setPassword("");
-			setMessage(t("loginPage.loginSuccess"));
+			setMessage(t("authModal.loginSuccess"));
 			onSuccess?.();
 		} catch (submitError) {
 			console.error(submitError);
 			setError(
 				submitError instanceof TypeError
-					? t("loginPage.networkError")
-					: t("loginPage.genericError"),
+					? t("authModal.networkError")
+					: t("authModal.genericError"),
 			);
 		} finally {
 			setIsSubmitting(false);
@@ -89,10 +270,15 @@ export const AuthForm = ({
 		setPassword("");
 	};
 
-	const handleGoogleLogin = () => {
-		setError("");
-		setMessage("Google login/signup is not implemented yet!");
-	};
+	const canUseGoogleButton =
+		isGoogleReady && !isGoogleSubmitting && !googleMissingClientId;
+	const googleButtonLabel = googleMissingClientId
+		? t("authModal.googleMissingClientId")
+		: isGoogleSubmitting
+			? t("authModal.googleSubmittingButton")
+			: mode === "login"
+				? t("authModal.googleLoginButton")
+				: t("authModal.googleSignupButton");
 
 	return (
 		<section
@@ -105,7 +291,7 @@ export const AuthForm = ({
 		>
 			<div className="auth-card-header">
 				<h1 id="auth-modal-title">
-					{mode === "login" ? t("loginPage.title") : t("loginPage.signupTitle")}
+					{mode === "login" ? t("authModal.title") : t("authModal.signupTitle")}
 				</h1>
 
 				{onClose ? (
@@ -127,7 +313,7 @@ export const AuthForm = ({
 					<InputField
 						id="email"
 						type="email"
-						placeholder={t("loginPage.emailLabel")}
+						placeholder={t("authModal.emailLabel")}
 						name="email"
 						autoComplete="email"
 						required
@@ -138,11 +324,11 @@ export const AuthForm = ({
 					<InputField
 						id="password"
 						type="password"
-						placeholder={t("loginPage.passwordLabel")}
+						placeholder={t("authModal.passwordLabel")}
 						name="password"
 						hint={
 							mode === "signup"
-								? t("loginPage.passwordRequirements")
+								? t("authModal.passwordRequirements")
 								: undefined
 						}
 						autoComplete={
@@ -157,7 +343,7 @@ export const AuthForm = ({
 						}
 						title={
 							mode === "signup"
-								? t("loginPage.passwordRequirements")
+								? t("authModal.passwordRequirements")
 								: undefined
 						}
 						required
@@ -175,35 +361,39 @@ export const AuthForm = ({
 					<MainButton type="submit" disabled={isSubmitting}>
 						{isSubmitting
 							? mode === "login"
-								? t("loginPage.submittingButton")
-								: t("loginPage.signupSubmittingButton")
+								? t("authModal.submittingButton")
+								: t("authModal.signupSubmittingButton")
 							: mode === "login"
-								? t("loginPage.logInButton")
-								: t("loginPage.signupButton")}
+								? t("authModal.logInButton")
+								: t("authModal.signupButton")}
 					</MainButton>
 
-					<MainButton
-						variant="inverted"
-						className="auth-social-button"
-						onClick={handleGoogleLogin}
-					>
-						<span className="auth-social-button-content">
+					<div className="auth-google-button-shell">
+						<button
+							type="button"
+							className="main-button inverted auth-social-button"
+							disabled={!canUseGoogleButton}
+							tabIndex={canUseGoogleButton ? -1 : undefined}
+							aria-hidden={canUseGoogleButton ? true : undefined}
+						>
 							<Google className="auth-social-google" />
-							<span>
-								{mode === "login"
-									? t("loginPage.googleLoginButton")
-									: t("loginPage.googleSignupButton")}
-							</span>
-						</span>
-					</MainButton>
+							<span>{googleButtonLabel}</span>
+						</button>
+
+						<div
+							ref={googleButtonRef}
+							className="auth-google-render-target"
+							aria-hidden={!canUseGoogleButton}
+						/>
+					</div>
 				</div>
 			</form>
 
 			<div className="auth-toggle">
 				<TextIconButton onClick={toggleMode} size="body2">
 					{mode === "login"
-						? t("loginPage.toggleSignupPrompt")
-						: t("loginPage.toggleLoginPrompt")}
+						? t("authModal.toggleSignupPrompt")
+						: t("authModal.toggleLoginPrompt")}
 				</TextIconButton>
 			</div>
 		</section>

--- a/frontend/app/components/auth/AuthForm.tsx
+++ b/frontend/app/components/auth/AuthForm.tsx
@@ -387,7 +387,8 @@ export const AuthForm = ({
 						<button
 							type="button"
 							className="main-button inverted auth-social-button"
-							disabled={!canUseGoogleButton}
+							data-google-ready={canUseGoogleButton}
+							disabled
 							tabIndex={canUseGoogleButton ? -1 : undefined}
 							aria-hidden={canUseGoogleButton ? true : undefined}
 						>

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -85,7 +85,7 @@
 		"avatar": "Avatar",
 		"noAvatar": "No avatar set"
 	},
-	"loginPage": {
+	"authModal": {
 		"title": "Log in",
 		"signupTitle": "Create an account",
 		"emailLabel": "Email address",
@@ -99,6 +99,10 @@
 		"logInButton": "Log in",
 		"googleLoginButton": "Log in with Google",
 		"googleSignupButton": "Sign up with Google",
+		"googleSubmittingButton": "Signing in with Google...",
+		"googleTokenError": "Google did not return a sign-in token.",
+		"googleMissingClientId": "Google client ID is not configured.",
+		"googleUnavailable": "Google sign-in is not available.",
 		"signupSubmittingButton": "Creating account...",
 		"signupSuccess": "Account created. You are signed in.",
 		"toggleSignupPrompt": "Need an account? Create one",

--- a/frontend/app/locales/fi/translation.json
+++ b/frontend/app/locales/fi/translation.json
@@ -85,7 +85,7 @@
 		"avatar": "Kuva",
 		"noAvatar": "Kuvaa ei ole asetettu"
 	},
-	"loginPage": {
+	"authModal": {
 		"title": "Kirjaudu sisään",
 		"signupTitle": "Luo tili",
 		"emailLabel": "Sähköpostiosoite",
@@ -99,6 +99,10 @@
 		"logInButton": "Kirjaudu sisään",
 		"googleLoginButton": "Kirjaudu sisään Googlella",
 		"googleSignupButton": "Luo tili Googlella",
+		"googleSubmittingButton": "Kirjaudutaan Googlella...",
+		"googleTokenError": "Google ei palauttanut kirjautumistunnusta.",
+		"googleMissingClientId": "Googlen asiakastunnusta ei ole määritetty.",
+		"googleUnavailable": "Google-kirjautuminen ei ole saatavilla.",
 		"signupSubmittingButton": "Luodaan tiliä...",
 		"signupSuccess": "Tili luotu. Olet kirjautunut sisään.",
 		"toggleSignupPrompt": "Tarvitsetko tilin? Luo sellainen",

--- a/frontend/app/locales/ru/translation.json
+++ b/frontend/app/locales/ru/translation.json
@@ -85,7 +85,7 @@
 		"avatar": "Аватар",
 		"noAvatar": "Аватар не установлен"
 	},
-	"loginPage": {
+	"authModal": {
 		"title": "Войти",
 		"signupTitle": "Создать аккаунт",
 		"emailLabel": "Email",
@@ -99,6 +99,10 @@
 		"logInButton": "Войти",
 		"googleLoginButton": "Войти через Google",
 		"googleSignupButton": "Зарегистрироваться через Google",
+		"googleSubmittingButton": "Вход через Google...",
+		"googleTokenError": "Google не вернул токен входа.",
+		"googleMissingClientId": "ID клиента Google не настроен.",
+		"googleUnavailable": "Вход через Google недоступен.",
 		"signupSubmittingButton": "Создается аккаунт...",
 		"signupSuccess": "Аккаунт создан. Вы вошли в систему.",
 		"toggleSignupPrompt": "Нет аккаунта? Создать",


### PR DESCRIPTION
Whats included:
- loads Google Identity Services script in AuthForm
- initializes Google with VITE_GOOGLE_CLIENT_ID
- renders the official Google button (switches between sign in / sign up based on mode)
- sends the Google credential to /auth/google
- adds handling for loading, missing config, and error states
- adds VITE_GOOGLE_CLIENT_ID to frontend env example
- rename loginPage translation namespace to authModal

Prerequisites
- Frontend and backend env google client variables set

close #195 