### PR TITLE
Attempt to fix "Wait for API Gateway to be ready" smoke test failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,8 +66,6 @@ services:
     ports:
       - "127.0.0.1:3000:3000"
 
-    #expose:
-    #  - "3000"
 
     environment:
       NODE_ENV: development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,8 +63,11 @@ services:
     container_name: api-gateway
     restart: unless-stopped
 
-    expose:
-      - "3000"
+    ports:
+      - "127.0.0.1:3000:3000"
+
+    #expose:
+    #  - "3000"
 
     environment:
       NODE_ENV: development


### PR DESCRIPTION
Change to api-gateway section of docker-compose.yml.

ports rather than expose because curl.