### PR TITLE
/auth/me isGoog return

### DIFF
--- a/backend/services/auth-service/src/authGetSet.ts
+++ b/backend/services/auth-service/src/authGetSet.ts
@@ -168,8 +168,9 @@ authGetSet.get(
 				return;
 			}
 			const email = userDocument.get("email");
+			const isGoog = userDocument.get("googleID") ? true : false;
 
-			res.status(200).json({ id: userId, email });
+			res.status(200).json({ id: userId, email, isGoog });
 		} catch (error) {
 			next(error);
 		}


### PR DESCRIPTION
 /auth/me now returns isGoog = true if the account is a google one and false if not.

curls work, no reason it shouldn't work elsewhere.