### PR TITLE
stabilize Google button rendering and clear stale error state

### DIFF
--- a/frontend/app/assets/styles/auth.css
+++ b/frontend/app/assets/styles/auth.css
@@ -17,41 +17,18 @@
 	gap: var(--space-m);
 }
 
-.main-button.inverted.auth-social-button {
-	background-color: var(--surface-card);
-	border: 1px solid var(--borders-action);
-	color: var(--text-primary);
-	height: auto;
-	min-height: 44px;
-	white-space: normal;
-	width: 100%;
-	pointer-events: none;
-}
-
-.main-button.inverted.auth-social-button[data-google-ready="true"]:disabled {
-	opacity: 1;
-}
-
-.auth-social-google {
-	stroke-width: 1;
-}
-
 .auth-google-button-shell {
-	position: relative;
 	display: flex;
 	justify-content: center;
-	width: 100%;
+	width: min(100%, 400px);
+	margin-inline: auto;
 }
 
 .auth-google-render-target {
-	position: absolute;
-	inset: 0;
-	z-index: 2;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	width: 100%;
-	opacity: 0;
 }
 
 .auth-google-render-target[aria-hidden="true"] {
@@ -86,6 +63,25 @@
 	flex-direction: column;
 	gap: var(--space-m);
 	margin-top: var(--space-s);
+}
+
+.auth-divider {
+	display: flex;
+	align-items: center;
+	gap: var(--space-s);
+	color: var(--text-secondary);
+	font-size: var(--fs-caption);
+	font-weight: var(--fw-caption);
+	line-height: var(--lh-caption);
+	text-transform: uppercase;
+}
+
+.auth-divider::before,
+.auth-divider::after {
+	content: "";
+	flex: 1;
+	height: 1px;
+	background-color: var(--borders-input);
 }
 
 .auth-error {

--- a/frontend/app/components/auth/AuthForm.tsx
+++ b/frontend/app/components/auth/AuthForm.tsx
@@ -367,17 +367,21 @@ export const AuthForm = ({
 								: t("authModal.signupButton")}
 					</MainButton>
 
-					<div className="auth-divider" aria-hidden="true">
-						<span>{t("authModal.orDivider")}</span>
-					</div>
+					{!googleMissingClientId ? (
+						<>
+							<div className="auth-divider" aria-hidden="true">
+								<span>{t("authModal.orDivider")}</span>
+							</div>
 
-					<div className="auth-google-button-shell">
-						<div
-							ref={googleButtonRef}
-							className="auth-google-render-target"
-							aria-hidden={!canUseGoogleButton}
-						/>
-					</div>
+							<div className="auth-google-button-shell">
+								<div
+									ref={googleButtonRef}
+									className="auth-google-render-target"
+									aria-hidden={!canUseGoogleButton}
+								/>
+							</div>
+						</>
+					) : null}
 				</div>
 			</form>
 

--- a/frontend/app/components/auth/AuthForm.tsx
+++ b/frontend/app/components/auth/AuthForm.tsx
@@ -1,4 +1,4 @@
-import { Google, Xmark } from "iconoir-react";
+import { Xmark } from "iconoir-react";
 import {
 	type FormEvent,
 	type RefObject,
@@ -36,8 +36,9 @@ declare global {
 						options: {
 							theme: "outline";
 							size: "large";
-							text: "signin_with" | "signup_with";
+							text: "signin_with" | "signup_with" | "continue_with" | "signin";
 							width: number;
+							locale?: string;
 						},
 					) => void;
 				};
@@ -55,6 +56,7 @@ type AuthFormProps = {
 
 const GOOGLE_IDENTITY_SCRIPT_SRC = "https://accounts.google.com/gsi/client";
 const GOOGLE_BUTTON_MIN_WIDTH = 240;
+const GOOGLE_BUTTON_MAX_WIDTH = 400;
 const GOOGLE_CLIENT_ID_PLACEHOLDER =
 	"123456789012-abc123def456gh789ijklmn0pqrstuvw.apps.googleusercontent.com";
 
@@ -109,7 +111,7 @@ export const AuthForm = ({
 	onClose,
 	onSuccess,
 }: AuthFormProps) => {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
 	const googleButtonRef = useRef<HTMLDivElement | null>(null);
 	const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
 	const googleMissingClientId =
@@ -121,7 +123,6 @@ export const AuthForm = ({
 	const [message, setMessage] = useState("");
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [isGoogleReady, setIsGoogleReady] = useState(false);
-	const [isGoogleSubmitting, setIsGoogleSubmitting] = useState(false);
 
 	const handleGoogleCredential = useCallback(
 		async (googleResponse: GoogleCredentialResponse) => {
@@ -132,8 +133,6 @@ export const AuthForm = ({
 				setError(t("authModal.googleTokenError"));
 				return;
 			}
-
-			setIsGoogleSubmitting(true);
 
 			try {
 				const response = await fetch(`${API_BASE_URL}/auth/google`, {
@@ -162,8 +161,6 @@ export const AuthForm = ({
 						? t("authModal.networkError")
 						: t("authModal.genericError"),
 				);
-			} finally {
-				setIsGoogleSubmitting(false);
 			}
 		},
 		[onSuccess, t],
@@ -193,13 +190,17 @@ export const AuthForm = ({
 				buttonContainer.replaceChildren();
 				const buttonWidth = Math.max(
 					GOOGLE_BUTTON_MIN_WIDTH,
-					Math.floor(buttonContainer.clientWidth),
+					Math.min(
+						GOOGLE_BUTTON_MAX_WIDTH,
+						Math.floor(buttonContainer.clientWidth),
+					),
 				);
 				window.google.accounts.id.renderButton(buttonContainer, {
 					theme: "outline",
 					size: "large",
-					text: mode === "login" ? "signin_with" : "signup_with",
+					text: "continue_with",
 					width: buttonWidth,
+					locale: i18n.resolvedLanguage ?? undefined,
 				});
 				setIsGoogleReady(true);
 			})
@@ -214,7 +215,7 @@ export const AuthForm = ({
 			isCurrent = false;
 			buttonContainer.replaceChildren();
 		};
-	}, [googleMissingClientId, handleGoogleCredential, mode, t]);
+	}, [googleMissingClientId, handleGoogleCredential, i18n.resolvedLanguage, t]);
 
 	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();
@@ -274,15 +275,7 @@ export const AuthForm = ({
 		setPassword("");
 	};
 
-	const canUseGoogleButton =
-		isGoogleReady && !isGoogleSubmitting && !googleMissingClientId;
-	const googleButtonLabel = googleMissingClientId
-		? t("authModal.googleMissingClientId")
-		: isGoogleSubmitting
-			? t("authModal.googleSubmittingButton")
-			: mode === "login"
-				? t("authModal.googleLoginButton")
-				: t("authModal.googleSignupButton");
+	const canUseGoogleButton = isGoogleReady && !googleMissingClientId;
 
 	return (
 		<section
@@ -315,6 +308,7 @@ export const AuthForm = ({
 			<form className="auth-form" onSubmit={handleSubmit}>
 				<div className="auth-fields">
 					<InputField
+						key={`email-${mode}`}
 						id="email"
 						type="email"
 						placeholder={t("authModal.emailLabel")}
@@ -326,6 +320,7 @@ export const AuthForm = ({
 					/>
 
 					<InputField
+						key={`password-${mode}`}
 						id="password"
 						type="password"
 						placeholder={t("authModal.passwordLabel")}
@@ -372,19 +367,11 @@ export const AuthForm = ({
 								: t("authModal.signupButton")}
 					</MainButton>
 
-					<div className="auth-google-button-shell">
-						<button
-							type="button"
-							className="main-button inverted auth-social-button"
-							data-google-ready={canUseGoogleButton}
-							disabled
-							tabIndex={canUseGoogleButton ? -1 : undefined}
-							aria-hidden={canUseGoogleButton ? true : undefined}
-						>
-							<Google className="auth-social-google" />
-							<span>{googleButtonLabel}</span>
-						</button>
+					<div className="auth-divider" aria-hidden="true">
+						<span>{t("authModal.orDivider")}</span>
+					</div>
 
+					<div className="auth-google-button-shell">
 						<div
 							ref={googleButtonRef}
 							className="auth-google-render-target"

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -147,6 +147,7 @@
 		"googleTokenError": "Google did not return a sign-in token.",
 		"googleMissingClientId": "Google client ID is not configured.",
 		"googleUnavailable": "Google sign-in is not available.",
+		"orDivider": "or",
 		"signupSubmittingButton": "Creating account...",
 		"signupSuccess": "Account created. You are signed in.",
 		"toggleSignupPrompt": "Need an account? Create one",

--- a/frontend/app/locales/fi/translation.json
+++ b/frontend/app/locales/fi/translation.json
@@ -147,6 +147,7 @@
 		"googleTokenError": "Google ei palauttanut kirjautumistunnusta.",
 		"googleMissingClientId": "Googlen asiakastunnusta ei ole määritetty.",
 		"googleUnavailable": "Google-kirjautuminen ei ole saatavilla.",
+		"orDivider": "tai",
 		"signupSubmittingButton": "Luodaan tiliä...",
 		"signupSuccess": "Tili luotu. Olet kirjautunut sisään.",
 		"toggleSignupPrompt": "Tarvitsetko tilin? Luo sellainen",

--- a/frontend/app/locales/ru/translation.json
+++ b/frontend/app/locales/ru/translation.json
@@ -147,6 +147,7 @@
 		"googleTokenError": "Google не вернул токен входа.",
 		"googleMissingClientId": "ID клиента Google не настроен.",
 		"googleUnavailable": "Вход через Google недоступен.",
+		"orDivider": "или",
 		"signupSubmittingButton": "Создается аккаунт...",
 		"signupSuccess": "Аккаунт создан. Вы вошли в систему.",
 		"toggleSignupPrompt": "Нет аккаунта? Создать",


### PR DESCRIPTION
Fix two bugs in auth modal

What changed
1. BUG in google button clickability
- removed the custom Google button wrapper and now render Google’s official button directly
- stopped re-rendering the Google button when switching between login and signup
- switched the Google button text to the neutral Continue with Google variant
- constrained the Google button container to a width supported by Google
- localized the Google button based on the app’s active language
- added an OR divider between email/password auth and Google sign-in
- If google login is unavailable, Google -button and OR -divider are hidden 


2. BUG in error state in inputfields
- reset auth form inputs when switching between login and signup so validation state does not leak between modes (Previously, if the user focused or triggered validation on the password field in login mode and then switched to create account, the password field in the new mode could still appear red even though the user had not interacted with it there.)

close #284 
close #285 