### PR TITLE
 fixes the recipe translation flow end to end

### DIFF
--- a/backend/services/core-service/src/services/recipes.service.ts
+++ b/backend/services/core-service/src/services/recipes.service.ts
@@ -296,14 +296,14 @@ const scheduleRecipeLocalization = (
 				`
 				UPDATE recipes
 				SET title = $1, description = $2, instructions = $3, updated_at = now()
-				WHERE id = $4 AND updated_at = $5
+				WHERE id = $4 AND date_trunc('milliseconds', updated_at) = $5::timestamptz
 			`,
 				[
 					localizedTitle,
 					localizedDescription,
 					localizedInstructions,
 					recipeId,
-					updatedAt,
+					updatedAt instanceof Date ? updatedAt.toISOString() : updatedAt,
 				],
 			);
 

--- a/frontend/app/components/RecipesGrid.tsx
+++ b/frontend/app/components/RecipesGrid.tsx
@@ -54,7 +54,8 @@ export const RecipesGrid = ({
 	sortValue = "",
 	userId,
 }: RecipesGridProps) => {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
+	const language = i18n.resolvedLanguage ?? "en";
 	const [recipeList, setRecipeList] = useState<RecipeCardResponse[]>([]);
 	const [isLoading, setIsLoading] = useState(true);
 	const [errorStatus, setErrorStatus] = useState<number | "unknown" | null>(
@@ -81,7 +82,9 @@ export const RecipesGrid = ({
 			userId !== undefined
 				? `${API_BASE_URL}/users/${userId}/recipes`
 				: `${API_BASE_URL}/recipes`;
-		fetch(endpoint)
+		fetch(endpoint, {
+			headers: { "X-Language": language },
+		})
 			.then((res) => {
 				if (!res.ok) {
 					setErrorStatus(res.status);
@@ -107,7 +110,7 @@ export const RecipesGrid = ({
 			.finally(() => {
 				setIsLoading(false);
 			});
-	}, [onLoad, sort, userId]);
+	}, [language, onLoad, sort, userId]);
 
 	const sortedList = useMemo(
 		() => sortRecipes(recipeList, sortValue),

--- a/frontend/app/routes/recipe-create.tsx
+++ b/frontend/app/routes/recipe-create.tsx
@@ -209,7 +209,8 @@ type CreateRecipeResponse = {
 
 const RecipeCreate = () => {
 	const baseId = useId();
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
+	const language = i18n.resolvedLanguage ?? "en";
 	const navigate = useNavigate();
 	const { isAuthenticated, isAuthResolved, openAuthModal } =
 		useOutletContext<LayoutOutletContext>();
@@ -448,7 +449,11 @@ const RecipeCreate = () => {
 			const response = await fetch(`${API_BASE_URL}/recipes`, {
 				method: "POST",
 				credentials: "include",
-				headers: { "Content-Type": "application/json" },
+				headers: {
+					"Content-Type": "application/json",
+					"X-Language": language,
+					"X-Source-Language": language,
+				},
 				body: JSON.stringify(payload),
 			});
 

--- a/frontend/app/routes/recipe.tsx
+++ b/frontend/app/routes/recipe.tsx
@@ -96,10 +96,12 @@ type FetchRecipeReviewsResult = {
 const fetchRecipeById = async (
 	id: string,
 	isAuthenticated: boolean,
+	language: string,
 ): Promise<FetchRecipeResult> => {
 	try {
 		const response = await fetch(`${API_BASE_URL}/recipes/${id}`, {
 			credentials: isAuthenticated ? "include" : "omit",
+			headers: { "X-Language": language },
 		});
 		if (!response.ok) {
 			return { errorStatus: response.status, recipe: null };
@@ -161,7 +163,8 @@ const RecipeLocationStateSchema = z.object({
 
 const RecipePage = () => {
 	const { id } = useParams();
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
+	const language = i18n.resolvedLanguage ?? "en";
 	const location = useLocation();
 	const { isAuthenticated, openAuthModal } =
 		useOutletContext<LayoutOutletContext>();
@@ -282,7 +285,7 @@ const RecipePage = () => {
 		}
 
 		const [recipeResult, reviewsResult] = await Promise.all([
-			fetchRecipeById(id, isAuthenticated),
+			fetchRecipeById(id, isAuthenticated, language),
 			fetchRecipeReviews(id),
 		]);
 
@@ -342,7 +345,7 @@ const RecipePage = () => {
 
 		// TODO: expose ownership in the recipe response so we can show an edit
 		// button only for the recipe author.
-		void fetchRecipeById(id, isAuthenticated)
+		void fetchRecipeById(id, isAuthenticated, language)
 			.then(({ errorStatus, recipe }) => {
 				setErrorStatus(errorStatus);
 				setRecipe(recipe);
@@ -350,7 +353,7 @@ const RecipePage = () => {
 			.finally(() => {
 				setIsLoading(false);
 			});
-	}, [id, isAuthenticated]);
+	}, [id, isAuthenticated, language]);
 
 	useEffect(() => {
 		if (!isAuthenticated) {

--- a/frontend/app/routes/user.tsx
+++ b/frontend/app/routes/user.tsx
@@ -42,7 +42,8 @@ type UserProfileData = z.infer<typeof UserResponseSchema>["data"];
 type FavoriteRecipe = z.infer<typeof FavoritesResponseSchema>["data"][number];
 
 const UserPage = () => {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
+	const language = i18n.resolvedLanguage ?? "en";
 	const { id } = useParams();
 	const { screenSize } = useScreenSize();
 	const { isAuthenticated, currentUserId, openAuthModal } =
@@ -115,6 +116,7 @@ const UserPage = () => {
 		const favoritesRequest = isAuthenticated
 			? fetch(`${API_BASE_URL}/users/${id}/favorites`, {
 					credentials: "include",
+					headers: { "X-Language": language },
 				})
 			: Promise.resolve(null);
 
@@ -164,7 +166,7 @@ const UserPage = () => {
 		return () => {
 			ignore = true;
 		};
-	}, [id, isOwnProfile, isAuthenticated]);
+	}, [id, isOwnProfile, isAuthenticated, language]);
 
 	const onFollowClick = () => {
 		if (!profile || isFollowPending) {


### PR DESCRIPTION
It makes recipe fetches use the selected site language, makes recipe creation send the source language of the submitted text, and fixes background localization so translated values are actually saved after translation succeeds.

## What changed

### Frontend
- Added `X-Language` to recipe list fetches in `RecipesGrid.tsx`
- Added `X-Language` to recipe detail fetches in `recipe.tsx`
- Added `X-Language` and `X-Source-Language` to recipe creation in `recipe-create.tsx`
- Added `X-Language` to user favorites fetches in user.tsx

### Backend
- Fixed the background localization update in `recipes.service.ts`
- The translation update could be skipped because PostgreSQL timestamp precision did not exactly match JavaScript `Date` precision
- The timestamp guard now compares at millisecond precision so successful translations are persisted

close #290 