### PR TITLE
added /auth/session to api gateway and use it for layout auth check in FE

### DIFF
--- a/backend/services/api-gateway/src/routes/auth.routes.ts
+++ b/backend/services/api-gateway/src/routes/auth.routes.ts
@@ -180,6 +180,24 @@ const patchChangePasswordHandler: RequestHandler = async (
 	}
 };
 
+const getSessionHandler: RequestHandler = async (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+) => {
+	try {
+		const headers = getAuthHeaders(req);
+		const response = await fetch(`${AUTH_SERVICE_URL}/session`, {
+			method: "GET",
+			headers,
+		});
+		const data = await response.json();
+		res.status(response.status).json(data);
+	} catch (error) {
+		next(error);
+	}
+};
+
 const getMeHandler: RequestHandler = async (
 	req: Request,
 	res: Response,
@@ -231,6 +249,7 @@ authRouter.post("/logout", postLogoutHandler);
 
 //authGetSet.ts handlers
 authRouter.post("/validate", postValidateHandler);
+authRouter.get("/session", getSessionHandler);
 authRouter.get("/me", getMeHandler);
 authRouter.delete("/delete", deleteUserHandler);
 authRouter.patch("/change-password", patchChangePasswordHandler);

--- a/frontend/app/layouts/layout.tsx
+++ b/frontend/app/layouts/layout.tsx
@@ -19,7 +19,8 @@ export type LayoutOutletContext = {
 	showNotice: (message: string) => void;
 };
 
-const ProfileIdSchema = z.object({ data: z.object({ id: z.number() }) });
+const SessionResponseSchema = z.object({ authenticated: z.boolean() });
+const AuthMeResponseSchema = z.object({ id: z.number() });
 
 const Layout = () => {
 	const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
@@ -40,6 +41,48 @@ const Layout = () => {
 		setCurrentUserId(null);
 	}, []);
 
+	const restoreAuthState = useCallback(async () => {
+		try {
+			const sessionResponse = await fetch(`${API_BASE_URL}/auth/session`, {
+				credentials: "include",
+			});
+
+			if (!sessionResponse.ok) {
+				resetAuthState();
+				return;
+			}
+
+			const sessionBody: unknown = await sessionResponse.json();
+			const parsedSession = SessionResponseSchema.safeParse(sessionBody);
+			if (!parsedSession.success || !parsedSession.data.authenticated) {
+				resetAuthState();
+				return;
+			}
+
+			const meResponse = await fetch(`${API_BASE_URL}/auth/me`, {
+				credentials: "include",
+			});
+			if (!meResponse.ok) {
+				resetAuthState();
+				return;
+			}
+
+			const meBody: unknown = await meResponse.json();
+			const parsedMe = AuthMeResponseSchema.safeParse(meBody);
+			if (!parsedMe.success) {
+				resetAuthState();
+				return;
+			}
+
+			setCurrentUserId(parsedMe.data.id);
+			setIsAuthenticated(true);
+		} catch {
+			resetAuthState();
+		} finally {
+			setIsAuthResolved(true);
+		}
+	}, [resetAuthState]);
+
 	const openAuthModal = (
 		onSuccessAction?: () => void,
 		onCancelAction?: () => void,
@@ -50,34 +93,8 @@ const Layout = () => {
 	};
 
 	useEffect(() => {
-		const restoreAuthState = async () => {
-			try {
-				const response = await fetch(`${API_BASE_URL}/profile`, {
-					credentials: "include",
-				});
-
-				if (!response.ok) {
-					resetAuthState();
-					return;
-				}
-
-				setIsAuthenticated(true);
-				const body: unknown = await response.json();
-				const parsed = ProfileIdSchema.safeParse(body);
-				setCurrentUserId(parsed.success ? parsed.data.data.id : null);
-			} catch {
-				resetAuthState();
-			} finally {
-				// Note: do NOT reset currentUserId here — the success branch above
-				// sets it to the signed-in user's id, and a blanket reset in finally
-				// would clobber that and break any `currentUserId === id` checks
-				// (e.g. the "own card → Profile button" branch in UserCard).
-				setIsAuthResolved(true);
-			}
-		};
-
 		void restoreAuthState();
-	}, [resetAuthState]);
+	}, [restoreAuthState]);
 
 	useEffect(() => {
 		if (!isAuthenticated) {
@@ -135,15 +152,8 @@ const Layout = () => {
 					authCancelActionRef.current = null;
 				}}
 				onSuccess={() => {
-					setIsAuthenticated(true);
 					setIsAuthModalOpen(false);
-					void fetch(`${API_BASE_URL}/profile`, { credentials: "include" })
-						.then((res) => (res.ok ? res.json() : null))
-						.then((body: unknown) => {
-							const parsed = ProfileIdSchema.safeParse(body);
-							setCurrentUserId(parsed.success ? parsed.data.data.id : null);
-						})
-						.catch(() => setCurrentUserId(null));
+					void restoreAuthState();
 					authSuccessActionRef.current?.();
 					authSuccessActionRef.current = null;
 					authCancelActionRef.current = null;


### PR DESCRIPTION
**BE changes**
GET /auth/session 
200 OK for every request
res.status(200).json({ authenticated: false });
or
res.status(200).json({ authenticated: true })

**FE changes**
call /auth/session to check whether the user is logged in
only if authenticated, call /auth/me to load the current user id
This avoids the guest-side /profile 401 in the browser console on initial load while keeping currentUserId available for existing UI logic

close #287  ?(hopefully)