### PR TITLE
Add on-demand review translation

### DIFF
--- a/backend/infrastructure/postgres/core/01-init-core.sql
+++ b/backend/infrastructure/postgres/core/01-init-core.sql
@@ -337,6 +337,7 @@ CREATE TABLE "recipe_reviews" (
   "recipe_id" integer NOT NULL,
   "author_id" integer NULL,
   "body" text NOT NULL,
+  "source_locale" text NOT NULL DEFAULT 'en' CHECK ("source_locale" IN ('en', 'fi', 'ru')),
   "is_deleted" boolean NOT NULL DEFAULT false,
   "created_at" timestamptz DEFAULT now(),
   "updated_at" timestamptz DEFAULT now(),

--- a/backend/services/api-gateway/src/__tests__/recipes.test.ts
+++ b/backend/services/api-gateway/src/__tests__/recipes.test.ts
@@ -1113,37 +1113,86 @@ describe("API Gateway - Recipes Routes", () => {
 		expect(response.body).toEqual({ error: "Recipe not found" });
 	});
 
-	it("should proxy POST /recipes/:id/reviews/:reviewId/translate to core-service", async () => {
-		fetchSpy.mockResolvedValue({
+	it("should proxy GET /recipes/:id/reviews/:reviewId/translate to core-service", async () => {
+		fetchSpy.mockResolvedValueOnce({
+			ok: true,
 			status: 200,
-			json: async () => ({
-				data: {
-					review_id: 501,
-					recipe_id: 77,
-					source_language: "en",
-					target_language: "fi",
-					original_body: "Great",
-					translated_body: "Loistava",
-				},
-			}),
+			json: async () => ({ id: 42 }),
+		} as unknown as Response);
+
+		fetchSpy.mockResolvedValueOnce({
+			status: 200,
+			text: async () =>
+				JSON.stringify({
+					data: {
+						review_id: 501,
+						recipe_id: 77,
+						source_language: "en",
+						target_language: "fi",
+						original_body: "Great",
+						translated_body: "Loistava",
+					},
+				}),
 		} as unknown as Response);
 
 		const response = await request(app)
-			.post("/recipes/77/reviews/501/translate")
+			.get("/recipes/77/reviews/501/translate")
+			.set("Authorization", "Bearer validtoken")
 			.set("X-Language", "fi");
 
 		expect(response.status).toBe(200);
 		expect(response.body.data).toHaveProperty("translated_body", "Loistava");
-		expect(fetchSpy).toHaveBeenCalledWith(
-			expect.stringContaining("/recipes/77/reviews/501/translate"),
+		expect(fetchSpy).toHaveBeenNthCalledWith(
+			1,
+			expect.stringContaining("/validate"),
 			expect.objectContaining({
 				method: "POST",
+				headers: { Authorization: "Bearer validtoken" },
+			}),
+		);
+		expect(fetchSpy).toHaveBeenNthCalledWith(
+			2,
+			expect.stringContaining("/recipes/77/reviews/501/translate"),
+			expect.objectContaining({
 				headers: expect.objectContaining({
 					"x-language": "fi",
+					"x-user-id": "42",
 				}),
 				signal: expect.any(AbortSignal),
 			}),
 		);
+	});
+
+	it("should reject GET /recipes/:id/reviews/:reviewId/translate without authentication", async () => {
+		const response = await request(app)
+			.get("/recipes/77/reviews/501/translate")
+			.set("X-Language", "fi");
+
+		expect(response.status).toBe(401);
+		expect(response.body).toEqual({ error: "Authentication required" });
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it("should preserve upstream status for non-JSON translate responses", async () => {
+		fetchSpy.mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ id: 42 }),
+		} as unknown as Response);
+
+		fetchSpy.mockResolvedValueOnce({
+			status: 502,
+			ok: false,
+			text: async () => "Bad gateway",
+		} as unknown as Response);
+
+		const response = await request(app)
+			.get("/recipes/77/reviews/501/translate")
+			.set("Authorization", "Bearer validtoken")
+			.set("X-Language", "fi");
+
+		expect(response.status).toBe(502);
+		expect(response.body).toEqual({ error: "Bad gateway" });
 	});
 
 	it("should reject PUT /recipes/:id/reviews/:reviewId without authentication", async () => {

--- a/backend/services/api-gateway/src/__tests__/recipes.test.ts
+++ b/backend/services/api-gateway/src/__tests__/recipes.test.ts
@@ -1033,6 +1033,7 @@ describe("API Gateway - Recipes Routes", () => {
 		const response = await request(app)
 			.post("/recipes/77/reviews")
 			.set("Authorization", "Bearer validtoken")
+			.set("X-Source-Language", "fi")
 			.send({ body: "Great" });
 
 		expect(response.status).toBe(201);
@@ -1048,6 +1049,7 @@ describe("API Gateway - Recipes Routes", () => {
 				method: "POST",
 				headers: expect.objectContaining({
 					"Content-Type": "application/json",
+					"x-source-language": "fi",
 					"x-user-id": "42",
 				}),
 				body: JSON.stringify({ body: "Great" }),
@@ -1109,6 +1111,39 @@ describe("API Gateway - Recipes Routes", () => {
 
 		expect(response.status).toBe(404);
 		expect(response.body).toEqual({ error: "Recipe not found" });
+	});
+
+	it("should proxy POST /recipes/:id/reviews/:reviewId/translate to core-service", async () => {
+		fetchSpy.mockResolvedValue({
+			status: 200,
+			json: async () => ({
+				data: {
+					review_id: 501,
+					recipe_id: 77,
+					source_language: "en",
+					target_language: "fi",
+					original_body: "Great",
+					translated_body: "Loistava",
+				},
+			}),
+		} as unknown as Response);
+
+		const response = await request(app)
+			.post("/recipes/77/reviews/501/translate")
+			.set("X-Language", "fi");
+
+		expect(response.status).toBe(200);
+		expect(response.body.data).toHaveProperty("translated_body", "Loistava");
+		expect(fetchSpy).toHaveBeenCalledWith(
+			expect.stringContaining("/recipes/77/reviews/501/translate"),
+			expect.objectContaining({
+				method: "POST",
+				headers: expect.objectContaining({
+					"x-language": "fi",
+				}),
+				signal: expect.any(AbortSignal),
+			}),
+		);
 	});
 
 	it("should reject PUT /recipes/:id/reviews/:reviewId without authentication", async () => {

--- a/backend/services/api-gateway/src/routes/recipes.routes.ts
+++ b/backend/services/api-gateway/src/routes/recipes.routes.ts
@@ -187,6 +187,32 @@ const getRecipeReviewsHandler: RequestHandler = async (req, res, _next) => {
 	}
 };
 
+const translateReviewHandler: RequestHandler = async (req, res, _next) => {
+	try {
+		const response = await fetch(
+			withForwardedQuery(
+				req,
+				`/recipes/${req.params.id}/reviews/${req.params.reviewId}/translate`,
+			),
+			{
+				method: "POST",
+				headers: getInternalHeaders(req),
+				signal: createTimeoutSignal(CORE_SERVICE_TIMEOUT_MS),
+			},
+		);
+		const data = await response.json();
+		res.status(response.status).json(data);
+	} catch (error) {
+		if (isTimeoutError(error)) {
+			res.status(504).json({ error: "Gateway Timeout" });
+			return;
+		}
+
+		console.error("Error proxying to core-service:", error);
+		res.status(500).json({ error: "Failed to translate review" });
+	}
+};
+
 const updateReviewHandler: RequestHandler = async (req, res, _next) => {
 	try {
 		const response = await fetch(
@@ -426,6 +452,11 @@ recipesRouter.get("/units", getUnitsHandler);
 recipesRouter.post("/:id/publish", requireAuth, publishRecipeHandler);
 recipesRouter.put("/:id/picture", requireAuth, updateRecipePictureHandler);
 recipesRouter.post("/:id/reviews", requireAuth, leaveRecipeReviewHandler);
+recipesRouter.post(
+	"/:id/reviews/:reviewId/translate",
+	optionalAuth,
+	translateReviewHandler,
+);
 recipesRouter.put("/:id/reviews/:reviewId", requireAuth, updateReviewHandler);
 recipesRouter.delete(
 	"/:id/reviews/:reviewId",

--- a/backend/services/api-gateway/src/routes/recipes.routes.ts
+++ b/backend/services/api-gateway/src/routes/recipes.routes.ts
@@ -32,6 +32,22 @@ const withForwardedQuery = (
 	return `${CORE_SERVICE_URL}${path}${req.originalUrl.slice(queryIndex)}`;
 };
 
+const forwardJsonOrTextResponse = async (
+	response: Response,
+	fallbackError: string,
+) => {
+	const rawBody = await response.text();
+	if (!rawBody) {
+		return { error: response.ok ? "" : fallbackError };
+	}
+
+	try {
+		return JSON.parse(rawBody) as unknown;
+	} catch {
+		return { error: rawBody };
+	}
+};
+
 // Create router for recipes
 export const recipesRouter = Router();
 
@@ -195,12 +211,14 @@ const translateReviewHandler: RequestHandler = async (req, res, _next) => {
 				`/recipes/${req.params.id}/reviews/${req.params.reviewId}/translate`,
 			),
 			{
-				method: "POST",
 				headers: getInternalHeaders(req),
 				signal: createTimeoutSignal(CORE_SERVICE_TIMEOUT_MS),
 			},
 		);
-		const data = await response.json();
+		const data = await forwardJsonOrTextResponse(
+			response,
+			"Failed to translate review",
+		);
 		res.status(response.status).json(data);
 	} catch (error) {
 		if (isTimeoutError(error)) {
@@ -452,9 +470,9 @@ recipesRouter.get("/units", getUnitsHandler);
 recipesRouter.post("/:id/publish", requireAuth, publishRecipeHandler);
 recipesRouter.put("/:id/picture", requireAuth, updateRecipePictureHandler);
 recipesRouter.post("/:id/reviews", requireAuth, leaveRecipeReviewHandler);
-recipesRouter.post(
+recipesRouter.get(
 	"/:id/reviews/:reviewId/translate",
-	optionalAuth,
+	requireAuth,
 	translateReviewHandler,
 );
 recipesRouter.put("/:id/reviews/:reviewId", requireAuth, updateReviewHandler);

--- a/backend/services/core-service/src/__tests__/recipes.test.ts
+++ b/backend/services/core-service/src/__tests__/recipes.test.ts
@@ -1863,15 +1863,15 @@ describe("Recipes Routes", () => {
 			reviewId = reviewResult.rows[0].id;
 
 			const response = await request(app)
-				.post(`/recipes/${recipeId}/reviews/${reviewId}/translate`)
-				.set("X-Language", "fi");
+				.get(`/recipes/${recipeId}/reviews/${reviewId}/translate`)
+				.set("X-Language", "en");
 
 			expect(response.status).toBe(200);
 			expect(response.body.data).toMatchObject({
 				review_id: reviewId,
 				recipe_id: recipeId,
 				source_language: "fi",
-				target_language: "fi",
+				target_language: "en",
 				original_body: "Todella hyvä resepti",
 				translated_body: "Todella hyvä resepti",
 			});
@@ -2077,6 +2077,73 @@ describe("Recipes Routes", () => {
 				]);
 			if (recipeId)
 				await pool.query(`DELETE FROM recipes WHERE id = $1`, [recipeId]);
+			await pool.query(`DELETE FROM users WHERE id IN ($1, $2)`, [
+				recipeAuthorId,
+				authorId,
+			]);
+		}
+	});
+
+	it("should keep existing review source locale when update omits X-Source-Language", async () => {
+		const authorId = 2407;
+		const recipeAuthorId = 2408;
+		let recipeId: number | null = null;
+		let reviewId: number | null = null;
+
+		try {
+			await pool.query(
+				`INSERT INTO users (id, username, role, status) VALUES ($1, $2, 'user', 'offline') ON CONFLICT (id) DO NOTHING`,
+				[recipeAuthorId, "update_review_keep_locale_owner"],
+			);
+			await pool.query(
+				`INSERT INTO users (id, username, role, status) VALUES ($1, $2, 'user', 'offline') ON CONFLICT (id) DO NOTHING`,
+				[authorId, "update_review_keep_locale_author"],
+			);
+
+			const recipeResult = await pool.query(
+				`INSERT INTO recipes (title, instructions, status, author_id)
+				 VALUES (
+					jsonb_build_object('en', 'Keep Locale Target', 'fi', 'Keep Locale Target', 'ru', 'Keep Locale Target'),
+					jsonb_build_object('en', to_jsonb(ARRAY['step']), 'fi', to_jsonb(ARRAY['step']), 'ru', to_jsonb(ARRAY['step'])),
+					'published',
+					$1
+				 ) RETURNING id`,
+				[recipeAuthorId],
+			);
+			recipeId = recipeResult.rows[0].id;
+
+			const reviewResult = await pool.query(
+				`INSERT INTO recipe_reviews (recipe_id, author_id, body, source_locale)
+				 VALUES ($1, $2, $3, $4)
+				 RETURNING id`,
+				[recipeId, authorId, "Alkuperainen arvio", "fi"],
+			);
+			reviewId = reviewResult.rows[0].id;
+
+			const response = await request(app)
+				.put(`/recipes/${recipeId}/reviews/${reviewId}`)
+				.set("X-User-Id", String(authorId))
+				.send({ body: "Paivitetty arvio" });
+
+			expect(response.status).toBe(200);
+			expect(response.body.data).toHaveProperty("body", "Paivitetty arvio");
+			expect(response.body.data).toHaveProperty("source_language", "fi");
+
+			const dbReview = await pool.query(
+				`SELECT body, source_locale FROM recipe_reviews WHERE id = $1`,
+				[reviewId],
+			);
+			expect(dbReview.rows[0].body).toBe("Paivitetty arvio");
+			expect(dbReview.rows[0].source_locale).toBe("fi");
+		} finally {
+			if (reviewId) {
+				await pool.query(`DELETE FROM recipe_reviews WHERE id = $1`, [
+					reviewId,
+				]);
+			}
+			if (recipeId) {
+				await pool.query(`DELETE FROM recipes WHERE id = $1`, [recipeId]);
+			}
 			await pool.query(`DELETE FROM users WHERE id IN ($1, $2)`, [
 				recipeAuthorId,
 				authorId,

--- a/backend/services/core-service/src/__tests__/recipes.test.ts
+++ b/backend/services/core-service/src/__tests__/recipes.test.ts
@@ -1604,6 +1604,13 @@ describe("Recipes Routes", () => {
 			expect(createResponse.body.data).toHaveProperty("recipe_id", recipeId);
 			expect(createResponse.body).toHaveProperty("message", "Review published");
 
+			const createdReviewId = createResponse.body.data.review_id;
+			const storedReview = await pool.query(
+				`SELECT source_locale FROM recipe_reviews WHERE id = $1`,
+				[createdReviewId],
+			);
+			expect(storedReview.rows[0].source_locale).toBe("en");
+
 			await pool.query(
 				`INSERT INTO recipe_ratings (recipe_id, user_id, rating) VALUES ($1, $2, $3)`,
 				[recipeId, reviewerId, 4],
@@ -1628,6 +1635,66 @@ describe("Recipes Routes", () => {
 			if (recipeId) {
 				await pool.query(`DELETE FROM recipe_ratings WHERE recipe_id = $1`, [
 					recipeId,
+				]);
+			}
+			if (recipeId) {
+				await pool.query(`DELETE FROM recipes WHERE id = $1`, [recipeId]);
+			}
+			await pool.query(`DELETE FROM users WHERE id IN ($1, $2)`, [
+				authorId,
+				reviewerId,
+			]);
+		}
+	});
+
+	it("should store review source locale from X-Source-Language", async () => {
+		const authorId = 2307;
+		const reviewerId = 2308;
+		let recipeId: number | null = null;
+		let reviewId: number | null = null;
+
+		try {
+			await pool.query(
+				`INSERT INTO users (id, username, role, status) VALUES ($1, $2, 'user', 'offline') ON CONFLICT (id) DO NOTHING`,
+				[authorId, "review_locale_recipe_author"],
+			);
+			await pool.query(
+				`INSERT INTO users (id, username, role, status) VALUES ($1, $2, 'user', 'offline') ON CONFLICT (id) DO NOTHING`,
+				[reviewerId, "review_locale_author"],
+			);
+
+			const recipeResult = await pool.query(
+				`INSERT INTO recipes (title, instructions, status, author_id)
+				 VALUES (
+					jsonb_build_object('en', 'Review Locale Target', 'fi', 'Review Locale Target', 'ru', 'Review Locale Target'),
+					jsonb_build_object('en', to_jsonb(ARRAY['step']), 'fi', to_jsonb(ARRAY['step']), 'ru', to_jsonb(ARRAY['step'])),
+					'published',
+					$1
+				 )
+				 RETURNING id`,
+				[authorId],
+			);
+			recipeId = recipeResult.rows[0].id;
+
+			const createResponse = await request(app)
+				.post(`/recipes/${recipeId}/reviews`)
+				.set("X-User-Id", String(reviewerId))
+				.set("X-Source-Language", "fi")
+				.send({ body: "Todella hyvä resepti" });
+
+			expect(createResponse.status).toBe(201);
+			reviewId = createResponse.body.data.review_id;
+
+			const storedReview = await pool.query(
+				`SELECT body, source_locale FROM recipe_reviews WHERE id = $1`,
+				[reviewId],
+			);
+			expect(storedReview.rows[0].body).toBe("Todella hyvä resepti");
+			expect(storedReview.rows[0].source_locale).toBe("fi");
+		} finally {
+			if (reviewId) {
+				await pool.query(`DELETE FROM recipe_reviews WHERE id = $1`, [
+					reviewId,
 				]);
 			}
 			if (recipeId) {
@@ -1756,6 +1823,79 @@ describe("Recipes Routes", () => {
 
 		expect(response.status).toBe(404);
 		expect(response.body).toHaveProperty("error");
+	});
+
+	it("should translate a review on demand without storing the translation", async () => {
+		const authorId = 2316;
+		const reviewerId = 2317;
+		let recipeId: number | null = null;
+		let reviewId: number | null = null;
+
+		try {
+			await pool.query(
+				`INSERT INTO users (id, username, role, status) VALUES ($1, $2, 'user', 'offline') ON CONFLICT (id) DO NOTHING`,
+				[authorId, "translate_review_recipe_author"],
+			);
+			await pool.query(
+				`INSERT INTO users (id, username, role, status) VALUES ($1, $2, 'user', 'offline') ON CONFLICT (id) DO NOTHING`,
+				[reviewerId, "translate_review_author"],
+			);
+
+			const recipeResult = await pool.query(
+				`INSERT INTO recipes (title, instructions, status, author_id)
+				 VALUES (
+					jsonb_build_object('en', 'Translate Review Target', 'fi', 'Translate Review Target', 'ru', 'Translate Review Target'),
+					jsonb_build_object('en', to_jsonb(ARRAY['step']), 'fi', to_jsonb(ARRAY['step']), 'ru', to_jsonb(ARRAY['step'])),
+					'published',
+					$1
+				 )
+				 RETURNING id`,
+				[authorId],
+			);
+			recipeId = recipeResult.rows[0].id;
+
+			const reviewResult = await pool.query(
+				`INSERT INTO recipe_reviews (recipe_id, author_id, body, source_locale)
+				 VALUES ($1, $2, $3, $4)
+				 RETURNING id`,
+				[recipeId, reviewerId, "Todella hyvä resepti", "fi"],
+			);
+			reviewId = reviewResult.rows[0].id;
+
+			const response = await request(app)
+				.post(`/recipes/${recipeId}/reviews/${reviewId}/translate`)
+				.set("X-Language", "fi");
+
+			expect(response.status).toBe(200);
+			expect(response.body.data).toMatchObject({
+				review_id: reviewId,
+				recipe_id: recipeId,
+				source_language: "fi",
+				target_language: "fi",
+				original_body: "Todella hyvä resepti",
+				translated_body: "Todella hyvä resepti",
+			});
+
+			const storedReview = await pool.query(
+				`SELECT body, source_locale FROM recipe_reviews WHERE id = $1`,
+				[reviewId],
+			);
+			expect(storedReview.rows[0].body).toBe("Todella hyvä resepti");
+			expect(storedReview.rows[0].source_locale).toBe("fi");
+		} finally {
+			if (reviewId) {
+				await pool.query(`DELETE FROM recipe_reviews WHERE id = $1`, [
+					reviewId,
+				]);
+			}
+			if (recipeId) {
+				await pool.query(`DELETE FROM recipes WHERE id = $1`, [recipeId]);
+			}
+			await pool.query(`DELETE FROM users WHERE id IN ($1, $2)`, [
+				authorId,
+				reviewerId,
+			]);
+		}
 	});
 
 	it("should return 401 for PUT /recipes/:id/reviews/:reviewId without authentication", async () => {
@@ -1914,6 +2054,7 @@ describe("Recipes Routes", () => {
 			const response = await request(app)
 				.put(`/recipes/${recipeId}/reviews/${reviewId}`)
 				.set("X-User-Id", String(authorId))
+				.set("X-Source-Language", "ru")
 				.send({ body: "Updated body" });
 
 			expect(response.status).toBe(200);
@@ -1924,10 +2065,11 @@ describe("Recipes Routes", () => {
 
 			// Verify DB was updated
 			const dbReview = await pool.query(
-				`SELECT body FROM recipe_reviews WHERE id = $1`,
+				`SELECT body, source_locale FROM recipe_reviews WHERE id = $1`,
 				[reviewId],
 			);
 			expect(dbReview.rows[0].body).toBe("Updated body");
+			expect(dbReview.rows[0].source_locale).toBe("ru");
 		} finally {
 			if (reviewId)
 				await pool.query(`DELETE FROM recipe_reviews WHERE id = $1`, [

--- a/backend/services/core-service/src/routes/recipes.routes.ts
+++ b/backend/services/core-service/src/routes/recipes.routes.ts
@@ -41,6 +41,7 @@ import {
 	updateReview,
 } from "../services/recipes.service.js";
 import {
+	resolveOptionalSourceLocale,
 	resolveRequestedLocale,
 	resolveSourceLocale,
 } from "../utils/locale.js";
@@ -860,7 +861,7 @@ const updateReviewHandler = async (
 			throw error;
 		}
 
-		const sourceLocale = resolveSourceLocale(req);
+		const sourceLocale = resolveOptionalSourceLocale(req);
 
 		const result = await updateReview(
 			recipeIdValidation.value,
@@ -993,7 +994,7 @@ recipesRouter.put(
 );
 
 recipesRouter.post("/:id/reviews", leaveRecipeReviewHandler);
-recipesRouter.post(
+recipesRouter.get(
 	"/:id/reviews/:reviewId/translate",
 	translateRecipeReviewHandler,
 );

--- a/backend/services/core-service/src/routes/recipes.routes.ts
+++ b/backend/services/core-service/src/routes/recipes.routes.ts
@@ -35,6 +35,7 @@ import {
 	leaveRecipeReview,
 	publishRecipe,
 	removeRecipeFromFavorites,
+	translateRecipeReview,
 	updateRecipe,
 	updateRecipePicture,
 	updateReview,
@@ -716,10 +717,13 @@ const leaveRecipeReviewHandler = async (
 			throw error;
 		}
 
+		const sourceLocale = resolveSourceLocale(req);
+
 		const result = await leaveRecipeReview(
 			idValidation.value,
 			req.userId,
 			bodyValidation.value,
+			sourceLocale,
 		);
 
 		if (!result.success) {
@@ -774,6 +778,45 @@ const getRecipeReviewsHandler = async (
 	}
 };
 
+const translateRecipeReviewHandler = async (
+	req: Request,
+	res: Response,
+	next: NextFunction,
+): Promise<void> => {
+	try {
+		const recipeIdValidation = validateRecipeId(req.params.id);
+		if (!recipeIdValidation.valid) {
+			const error: CustomError = new Error(recipeIdValidation.error);
+			error.statusCode = 400;
+			throw error;
+		}
+
+		const reviewIdValidation = validateReviewId(req.params.reviewId);
+		if (!reviewIdValidation.valid) {
+			const error: CustomError = new Error(reviewIdValidation.error);
+			error.statusCode = 400;
+			throw error;
+		}
+
+		const locale = resolveRequestedLocale(req);
+		const result = await translateRecipeReview(
+			recipeIdValidation.value,
+			reviewIdValidation.value,
+			locale,
+		);
+
+		if (!result.success) {
+			const error: CustomError = new Error("Review not found");
+			error.statusCode = 404;
+			throw error;
+		}
+
+		res.status(200).json({ data: result.translation });
+	} catch (error) {
+		next(error);
+	}
+};
+
 /**
  * PUT /recipes/:id/reviews/:reviewId - update a review
  *
@@ -817,11 +860,14 @@ const updateReviewHandler = async (
 			throw error;
 		}
 
+		const sourceLocale = resolveSourceLocale(req);
+
 		const result = await updateReview(
 			recipeIdValidation.value,
 			reviewIdValidation.value,
 			req.userId,
 			bodyValidation.value,
+			sourceLocale,
 		);
 
 		if (!result.success) {
@@ -947,6 +993,10 @@ recipesRouter.put(
 );
 
 recipesRouter.post("/:id/reviews", leaveRecipeReviewHandler);
+recipesRouter.post(
+	"/:id/reviews/:reviewId/translate",
+	translateRecipeReviewHandler,
+);
 recipesRouter.put("/:id/reviews/:reviewId", updateReviewHandler);
 recipesRouter.delete(
 	"/:id/reviews/:reviewId",

--- a/backend/services/core-service/src/services/recipes.service.ts
+++ b/backend/services/core-service/src/services/recipes.service.ts
@@ -38,6 +38,7 @@ import {
 	type SearchRecipeDocument,
 	type SupportedLocale,
 	searchRecipeDocumentSchema,
+	supportedLocaleSchema,
 	type UpdateRecipeInput,
 	type UpdateRecipeReviewInput,
 } from "../validation/schemas.js";
@@ -45,6 +46,7 @@ import { scheduleRecipeSearchReindex } from "./searchIndex.service.js";
 import {
 	localizeInstructionStepsFromSource,
 	localizeTextFromSource,
+	translateTextToLocale,
 } from "./translation.service.js";
 
 type PublishRecipeResult =
@@ -101,6 +103,20 @@ type UpdateReviewResult =
 	| { success: true; review: RecipeReviewListItem }
 	| { success: false; reason: "not-found" | "forbidden" };
 
+type TranslateReviewResult =
+	| {
+			success: true;
+			translation: {
+				review_id: number;
+				recipe_id: number;
+				source_language: SupportedLocale;
+				target_language: SupportedLocale;
+				original_body: string;
+				translated_body: string;
+			};
+	  }
+	| { success: false; reason: "not-found" };
+
 type DeleteReviewResult =
 	| { success: true; reviewId: number; recipeId: number; updatedAt: string }
 	| { success: false; reason: "not-found" | "forbidden" };
@@ -118,6 +134,12 @@ const recipeIdRowSchema = z.object({
 const recipeVisibilityRowSchema = z.object({
 	author_id: z.coerce.number().int().positive().nullable(),
 	status: recipeStatusSchema,
+});
+
+const recipeReviewTranslationRowSchema = z.object({
+	recipe_id: z.coerce.number().int().positive(),
+	body: z.string().trim().min(1),
+	source_locale: supportedLocaleSchema,
 });
 
 const requesterRoleRowSchema = z.object({
@@ -1115,6 +1137,7 @@ export const leaveRecipeReview = async (
 	recipeId: number,
 	userId: number,
 	input: CreateRecipeReviewInput,
+	sourceLocale: SupportedLocale = DEFAULT_LOCALE,
 ): Promise<LeaveRecipeReviewResult> => {
 	try {
 		const authorExists = await userExists(userId);
@@ -1129,11 +1152,11 @@ export const leaveRecipeReview = async (
 
 		const result = await pool.query(
 			`
-			INSERT INTO recipe_reviews (recipe_id, author_id, body)
-			VALUES ($1, $2, $3)
+			INSERT INTO recipe_reviews (recipe_id, author_id, body, source_locale)
+			VALUES ($1, $2, $3, $4)
 			RETURNING id
 		`,
-			[recipeId, userId, input.body],
+			[recipeId, userId, input.body, sourceLocale],
 		);
 
 		const reviewIdParsed = recipeIdRowSchema.safeParse(result.rows[0]);
@@ -1208,6 +1231,7 @@ export const updateReview = async (
 	reviewId: number,
 	userId: number,
 	input: UpdateRecipeReviewInput,
+	sourceLocale: SupportedLocale = DEFAULT_LOCALE,
 ): Promise<UpdateReviewResult> => {
 	try {
 		const existingResult = await pool.query(
@@ -1227,11 +1251,11 @@ export const updateReview = async (
 		await pool.query(
 			`
 			UPDATE recipe_reviews
-			SET body = $1, updated_at = now()
-			WHERE id = $2
+			SET body = $1, source_locale = $2, updated_at = now()
+			WHERE id = $3
 			RETURNING id, recipe_id, author_id, body, created_at, updated_at
 		`,
-			[input.body, reviewId],
+			[input.body, sourceLocale, reviewId],
 		);
 
 		// Join user data to match the RecipeReviewListItem shape
@@ -1267,6 +1291,63 @@ export const updateReview = async (
 		return { success: true, review: reviewParsed.data };
 	} catch (error) {
 		console.error("Database error in updateReview:", error);
+		throw error;
+	}
+};
+
+export const translateRecipeReview = async (
+	recipeId: number,
+	reviewId: number,
+	targetLocale: SupportedLocale = DEFAULT_LOCALE,
+): Promise<TranslateReviewResult> => {
+	try {
+		const result = await pool.query(
+			`
+			SELECT
+				rr.recipe_id,
+				rr.body,
+				rr.source_locale
+			FROM recipe_reviews rr
+			JOIN recipes r ON r.id = rr.recipe_id
+			WHERE
+				rr.id = $1
+				AND rr.recipe_id = $2
+				AND rr.is_deleted = false
+				AND r.status = 'published'
+		`,
+			[reviewId, recipeId],
+		);
+
+		if (result.rowCount === 0) {
+			return { success: false, reason: "not-found" };
+		}
+
+		const parsedReview = recipeReviewTranslationRowSchema.safeParse(
+			result.rows[0],
+		);
+		if (!parsedReview.success) {
+			throw new Error(z.prettifyError(parsedReview.error));
+		}
+
+		const translatedBody = await translateTextToLocale(
+			parsedReview.data.body,
+			parsedReview.data.source_locale,
+			targetLocale,
+		);
+
+		return {
+			success: true,
+			translation: {
+				review_id: reviewId,
+				recipe_id: parsedReview.data.recipe_id,
+				source_language: parsedReview.data.source_locale,
+				target_language: targetLocale,
+				original_body: parsedReview.data.body,
+				translated_body: translatedBody,
+			},
+		};
+	} catch (error) {
+		console.error("Database error in translateRecipeReview:", error);
 		throw error;
 	}
 };

--- a/backend/services/core-service/src/services/recipes.service.ts
+++ b/backend/services/core-service/src/services/recipes.service.ts
@@ -126,6 +126,8 @@ interface ErrorWithCode extends Error {
 }
 
 const USER_NOT_FOUND_CODE = "USER_NOT_FOUND";
+const REVIEW_TRANSLATION_CACHE_LIMIT = 100;
+const reviewTranslationCache = new Map<string, string>();
 
 const recipeIdRowSchema = z.object({
 	id: z.coerce.number().int().positive(),
@@ -140,6 +142,7 @@ const recipeReviewTranslationRowSchema = z.object({
 	recipe_id: z.coerce.number().int().positive(),
 	body: z.string().trim().min(1),
 	source_locale: supportedLocaleSchema,
+	updated_at: z.coerce.date().transform((value) => value.toISOString()),
 });
 
 const requesterRoleRowSchema = z.object({
@@ -1238,7 +1241,7 @@ export const updateReview = async (
 	reviewId: number,
 	userId: number,
 	input: UpdateRecipeReviewInput,
-	sourceLocale: SupportedLocale = DEFAULT_LOCALE,
+	sourceLocale?: SupportedLocale,
 ): Promise<UpdateReviewResult> => {
 	try {
 		const existingResult = await pool.query(
@@ -1258,7 +1261,7 @@ export const updateReview = async (
 		await pool.query(
 			`
 			UPDATE recipe_reviews
-			SET body = $1, source_locale = $2, updated_at = now()
+			SET body = $1, source_locale = COALESCE($2, source_locale), updated_at = now()
 			WHERE id = $3
 			RETURNING id, recipe_id, author_id, body, created_at, updated_at
 		`,
@@ -1314,7 +1317,8 @@ export const translateRecipeReview = async (
 			SELECT
 				rr.recipe_id,
 				rr.body,
-				rr.source_locale
+				rr.source_locale,
+				rr.updated_at
 			FROM recipe_reviews rr
 			JOIN recipes r ON r.id = rr.recipe_id
 			WHERE
@@ -1337,11 +1341,27 @@ export const translateRecipeReview = async (
 			throw new Error(z.prettifyError(parsedReview.error));
 		}
 
-		const translatedBody = await translateTextToLocale(
-			parsedReview.data.body,
+		const cacheKey = [
+			reviewId,
 			parsedReview.data.source_locale,
 			targetLocale,
-		);
+			parsedReview.data.updated_at,
+		].join(":");
+		let translatedBody = reviewTranslationCache.get(cacheKey);
+		if (!translatedBody) {
+			translatedBody = await translateTextToLocale(
+				parsedReview.data.body,
+				parsedReview.data.source_locale,
+				targetLocale,
+			);
+			reviewTranslationCache.set(cacheKey, translatedBody);
+			if (reviewTranslationCache.size > REVIEW_TRANSLATION_CACHE_LIMIT) {
+				const oldestKey = reviewTranslationCache.keys().next().value;
+				if (oldestKey) {
+					reviewTranslationCache.delete(oldestKey);
+				}
+			}
+		}
 
 		return {
 			success: true,

--- a/backend/services/core-service/src/services/recipes.service.ts
+++ b/backend/services/core-service/src/services/recipes.service.ts
@@ -1196,6 +1196,7 @@ export const getRecipeReviews = async (
 				u.avatar,
 				rrt.rating,
 				rr.body,
+				rr.source_locale AS source_language,
 				rr.created_at,
 				rr.updated_at
 			FROM recipe_reviews rr
@@ -1275,6 +1276,7 @@ export const updateReview = async (
 				u.avatar,
 				rrt.rating,
 				rr.body,
+				rr.source_locale AS source_language,
 				rr.created_at,
 				rr.updated_at
 			FROM recipe_reviews rr

--- a/backend/services/core-service/src/services/translation.service.ts
+++ b/backend/services/core-service/src/services/translation.service.ts
@@ -307,6 +307,26 @@ export const localizeTextFromSource = async (
 };
 
 /**
+ * Translate one text to a single target locale without storing anything.
+ *
+ * If translation is unavailable, returns the original text as a safe fallback.
+ */
+export const translateTextToLocale = async (
+	sourceText: string,
+	sourceLocale: SupportedLocale = DEFAULT_LOCALE,
+	targetLocale: SupportedLocale = DEFAULT_LOCALE,
+): Promise<string> => {
+	const safeSource = sourceText.trim();
+
+	if (safeSource.length === 0 || sourceLocale === targetLocale) {
+		return safeSource;
+	}
+
+	const localized = await localizeTextFromSource(safeSource, sourceLocale);
+	return localized[targetLocale];
+};
+
+/**
  * Localize multiple texts in parallel, using a batch API call when available.
  */
 const localizeTextsFromSource = async (

--- a/backend/services/core-service/src/services/translation.service.ts
+++ b/backend/services/core-service/src/services/translation.service.ts
@@ -161,6 +161,7 @@ const normalizeBatchedTranslations = (
 const requestTranslations = async (
 	sourceText: string,
 	sourceLocale: SupportedLocale = DEFAULT_LOCALE,
+	targetLocales: SupportedLocale[] = getTargetLocales(sourceLocale),
 ): Promise<Partial<Record<SupportedLocale, string>> | null> => {
 	// If no translation service is configured, skip external call
 	if (!TRANSLATION_API_URL) {
@@ -178,7 +179,7 @@ const requestTranslations = async (
 			},
 			body: JSON.stringify({
 				source_language: sourceLocale,
-				target_languages: getTargetLocales(sourceLocale),
+				target_languages: targetLocales,
 				text: sourceText,
 			}),
 			signal: timeoutSignal(),
@@ -322,8 +323,10 @@ export const translateTextToLocale = async (
 		return safeSource;
 	}
 
-	const localized = await localizeTextFromSource(safeSource, sourceLocale);
-	return localized[targetLocale];
+	const translations = await requestTranslations(safeSource, sourceLocale, [
+		targetLocale,
+	]);
+	return sanitizeTranslation(translations?.[targetLocale]) ?? safeSource;
 };
 
 /**

--- a/backend/services/core-service/src/utils/locale.ts
+++ b/backend/services/core-service/src/utils/locale.ts
@@ -76,3 +76,15 @@ export const resolveSourceLocale = (req: Request): SupportedLocale => {
 
 	return resolveRequestedLocale(req);
 };
+
+export const resolveOptionalSourceLocale = (
+	req: Request,
+): SupportedLocale | undefined => {
+	const headerLocale = parseLanguageHeader(req.headers["x-source-language"]);
+	if (!headerLocale) {
+		return undefined;
+	}
+
+	const parsed = validateLocale(headerLocale);
+	return parsed.valid ? parsed.value : undefined;
+};

--- a/backend/services/core-service/src/validation/schemas.ts
+++ b/backend/services/core-service/src/validation/schemas.ts
@@ -316,6 +316,7 @@ export const recipeReviewListItemSchema = z.object({
 	avatar: z.string().nullable(),
 	rating: z.coerce.number().int().min(1).max(5).nullable(),
 	body: z.string(),
+	source_language: supportedLocaleSchema,
 	created_at: z.coerce.date().transform((value) => value.toISOString()),
 	updated_at: z.coerce.date().transform((value) => value.toISOString()),
 });

--- a/frontend/app/assets/styles/recipe.css
+++ b/frontend/app/assets/styles/recipe.css
@@ -202,6 +202,16 @@
 	flex: 0 0 var(--icon-button-size);
 }
 
+.recipe-page-review-translate-row {
+	display: flex;
+	justify-content: flex-start;
+}
+
+.recipe-page-review-translate svg {
+	color: var(--icons-dark);
+	flex-shrink: 0;
+}
+
 .recipe-page-review-author {
 	color: var(--text-secondary);
 	flex: 1 1 auto;

--- a/frontend/app/components/review/reviewForm.tsx
+++ b/frontend/app/components/review/reviewForm.tsx
@@ -25,7 +25,8 @@ export const ReviewForm = ({
 	onSuccess,
 	recipeId,
 }: ReviewFormProps) => {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
+	const language = i18n.resolvedLanguage ?? "en";
 	const [review, setReview] = useState("");
 	const [error, setError] = useState("");
 	const [isSubmitting, setIsSubmitting] = useState(false);
@@ -60,6 +61,8 @@ export const ReviewForm = ({
 					method: "POST",
 					headers: {
 						"Content-Type": "application/json",
+						"X-Language": language,
+						"X-Source-Language": language,
 					},
 					credentials: "include",
 					body: JSON.stringify({ body: trimmedReview }),

--- a/frontend/app/components/review/reviewForm.tsx
+++ b/frontend/app/components/review/reviewForm.tsx
@@ -19,6 +19,9 @@ const ApiResponseSchema = z.object({
 	message: z.string().optional(),
 });
 
+const normalizeLanguage = (value: string | undefined) =>
+	(value ?? "en").slice(0, 2).toLowerCase();
+
 export const ReviewForm = ({
 	dialogRef,
 	onClose,
@@ -26,7 +29,7 @@ export const ReviewForm = ({
 	recipeId,
 }: ReviewFormProps) => {
 	const { t, i18n } = useTranslation();
-	const language = i18n.resolvedLanguage ?? "en";
+	const language = normalizeLanguage(i18n.resolvedLanguage);
 	const [review, setReview] = useState("");
 	const [error, setError] = useState("");
 	const [isSubmitting, setIsSubmitting] = useState(false);

--- a/frontend/app/locales/en/translation.json
+++ b/frontend/app/locales/en/translation.json
@@ -75,6 +75,10 @@
 		"reviewAnonymous": "Deleted user",
 		"confirmDeleteReview": "Delete your review?",
 		"deleteReviewError": "Failed to delete review (status: {{status}}).",
+		"translateReview": "Translate",
+		"translatingReview": "Translating...",
+		"showOriginalReview": "Show original",
+		"translateReviewError": "Failed to translate review (status: {{status}}).",
 		"step": "Step {{number}}",
 		"pictureUploadFailedWarning": "Recipe created, but the photo could not be uploaded. A default image is being used — you can try adding a photo again later."
 	},

--- a/frontend/app/locales/fi/translation.json
+++ b/frontend/app/locales/fi/translation.json
@@ -75,6 +75,10 @@
 		"reviewAnonymous": "Poistettu käyttäjä",
 		"confirmDeleteReview": "Poistetaanko arvostelusi?",
 		"deleteReviewError": "Arvostelun poistaminen epäonnistui (tila: {{status}}).",
+		"translateReview": "Käännä",
+		"translatingReview": "Käännetään...",
+		"showOriginalReview": "Näytä alkuperäinen",
+		"translateReviewError": "Arvostelun kääntäminen epäonnistui (tila: {{status}}).",
 		"step": "Vaihe {{number}}",
 		"pictureUploadFailedWarning": "Resepti luotiin, mutta kuvan lataus epäonnistui. Käytössä on oletuskuva — voit yrittää lisätä kuvan myöhemmin uudelleen."
 	},

--- a/frontend/app/locales/ru/translation.json
+++ b/frontend/app/locales/ru/translation.json
@@ -75,6 +75,10 @@
 		"reviewAnonymous": "Удаленный пользователь",
 		"confirmDeleteReview": "Удалить ваш отзыв?",
 		"deleteReviewError": "Не удалось удалить отзыв (статус: {{status}}).",
+		"translateReview": "Перевести",
+		"translatingReview": "Перевод...",
+		"showOriginalReview": "Показать оригинал",
+		"translateReviewError": "Не удалось перевести отзыв (статус: {{status}}).",
 		"step": "Шаг {{number}}",
 		"pictureUploadFailedWarning": "Рецепт создан, но загрузить фото не удалось. Используется стандартное изображение — можно попробовать добавить фото позже."
 	},

--- a/frontend/app/routes/recipe.tsx
+++ b/frontend/app/routes/recipe.tsx
@@ -35,15 +35,6 @@ type Recipe = {
 	instructions: string[];
 };
 
-type RecipeReview = {
-	id: number;
-	author_id: number | null;
-	username: string | null;
-	body: string;
-	source_language: string;
-	created_at: string;
-};
-
 const RecipeIngredientSchema = z.object({
 	ingredient_id: z.number(),
 	amount: z.number(),
@@ -67,18 +58,23 @@ const RecipeResponseSchema = z.object({
 	data: RecipeSchema,
 });
 
+const ReviewLanguageSchema = z.enum(["en", "fi", "ru"]);
+
 const RecipeReviewSchema = z.object({
 	id: z.number(),
 	author_id: z.number().nullable(),
 	username: z.string().nullable(),
 	body: z.string(),
-	source_language: z.enum(["en", "fi", "ru"]),
+	source_language: ReviewLanguageSchema,
 	created_at: z.string(),
+	updated_at: z.string(),
 });
 
 const RecipeReviewsResponseSchema = z.object({
 	data: z.array(RecipeReviewSchema),
 });
+
+type RecipeReview = z.infer<typeof RecipeReviewSchema>;
 
 const ReviewTranslationResponseSchema = z.object({
 	data: z.object({
@@ -92,6 +88,14 @@ const ProfileResponseSchema = z.object({
 		id: z.number(),
 	}),
 });
+
+type ReviewLanguage = z.infer<typeof ReviewLanguageSchema>;
+
+const normalizeReviewLanguage = (value: string | undefined): ReviewLanguage => {
+	const normalized = (value ?? "en").slice(0, 2).toLowerCase();
+	const parsed = ReviewLanguageSchema.safeParse(normalized);
+	return parsed.success ? parsed.data : "en";
+};
 
 type FetchRecipeResult = {
 	errorStatus: number | "unknown" | null;
@@ -174,7 +178,7 @@ const RecipeLocationStateSchema = z.object({
 const RecipePage = () => {
 	const { id } = useParams();
 	const { t, i18n } = useTranslation();
-	const language = i18n.resolvedLanguage ?? "en";
+	const language = normalizeReviewLanguage(i18n.resolvedLanguage);
 	const location = useLocation();
 	const { isAuthenticated, openAuthModal } =
 		useOutletContext<LayoutOutletContext>();
@@ -204,7 +208,10 @@ const RecipePage = () => {
 		null,
 	);
 	const [translatedReviewBodies, setTranslatedReviewBodies] = useState<
-		Record<number, { body: string; language: string }>
+		Record<
+			number,
+			{ body: string; language: ReviewLanguage; updatedAt: string }
+		>
 	>({});
 	const [visibleTranslatedReviewIds, setVisibleTranslatedReviewIds] = useState<
 		Record<number, boolean>
@@ -358,8 +365,23 @@ const RecipePage = () => {
 			return;
 		}
 
+		if (!isAuthenticated) {
+			openAuthModal(() => {
+				void translateReview(reviewId);
+			});
+			return;
+		}
+
+		const review = reviews.find((item) => item.id === reviewId);
+		if (!review) {
+			return;
+		}
+
 		const currentTranslation = translatedReviewBodies[reviewId];
-		if (currentTranslation?.language === language) {
+		if (
+			currentTranslation?.language === language &&
+			currentTranslation.updatedAt === review.updated_at
+		) {
 			setVisibleTranslatedReviewIds((current) => ({
 				...current,
 				[reviewId]: !current[reviewId],
@@ -374,7 +396,6 @@ const RecipePage = () => {
 			const response = await fetch(
 				`${API_BASE_URL}/recipes/${id}/reviews/${reviewId}/translate`,
 				{
-					method: "POST",
 					headers: {
 						"X-Language": language,
 					},
@@ -404,6 +425,7 @@ const RecipePage = () => {
 				[parsed.data.data.review_id]: {
 					body: parsed.data.data.translated_body,
 					language,
+					updatedAt: review.updated_at,
 				},
 			}));
 			setVisibleTranslatedReviewIds((current) => ({
@@ -730,6 +752,7 @@ const RecipePage = () => {
 									const translatedReview = translatedReviewBodies[review.id];
 									const isReviewTranslated =
 										translatedReview?.language === language &&
+										translatedReview.updatedAt === review.updated_at &&
 										visibleTranslatedReviewIds[review.id] === true;
 									const isReviewTranslating = translatingReviewId === review.id;
 									const canTranslateReview =

--- a/frontend/app/routes/recipe.tsx
+++ b/frontend/app/routes/recipe.tsx
@@ -4,8 +4,9 @@ import { useLocation, useOutletContext, useParams } from "react-router";
 import { z } from "zod";
 import recipeImg from "../assets/images/vegetable-side-dishes.jpg";
 import "../assets/styles/recipe.css";
-import { Reports, StarSolid, Trash } from "iconoir-react";
+import { Reports, StarSolid, Translate, Trash } from "iconoir-react";
 import { IconButton } from "~/components/buttons/IconButton";
+import { TextIconButton } from "~/components/buttons/TextIconButton";
 import { ConfirmationModal } from "~/components/ConfirmationModal";
 import { RatingModal } from "~/components/rating/ratingModal";
 import { ReviewModal } from "~/components/review/reviewModal";
@@ -39,6 +40,7 @@ type RecipeReview = {
 	author_id: number | null;
 	username: string | null;
 	body: string;
+	source_language: string;
 	created_at: string;
 };
 
@@ -70,11 +72,19 @@ const RecipeReviewSchema = z.object({
 	author_id: z.number().nullable(),
 	username: z.string().nullable(),
 	body: z.string(),
+	source_language: z.enum(["en", "fi", "ru"]),
 	created_at: z.string(),
 });
 
 const RecipeReviewsResponseSchema = z.object({
 	data: z.array(RecipeReviewSchema),
+});
+
+const ReviewTranslationResponseSchema = z.object({
+	data: z.object({
+		review_id: z.number(),
+		translated_body: z.string(),
+	}),
 });
 
 const ProfileResponseSchema = z.object({
@@ -190,6 +200,15 @@ const RecipePage = () => {
 		number | null
 	>(null);
 	const [deletingReviewId, setDeletingReviewId] = useState<number | null>(null);
+	const [translatingReviewId, setTranslatingReviewId] = useState<number | null>(
+		null,
+	);
+	const [translatedReviewBodies, setTranslatedReviewBodies] = useState<
+		Record<number, { body: string; language: string }>
+	>({});
+	const [visibleTranslatedReviewIds, setVisibleTranslatedReviewIds] = useState<
+		Record<number, boolean>
+	>({});
 	const [reviewActionError, setReviewActionError] = useState("");
 	const [isFavorited, setIsFavorited] = useState(false);
 	const [isFavoritePending, setIsFavoritePending] = useState(false);
@@ -294,6 +313,8 @@ const RecipePage = () => {
 		setReviewsErrorStatus(reviewsResult.errorStatus);
 		setReviews(reviewsResult.reviews);
 		setReviewActionError("");
+		setTranslatedReviewBodies({});
+		setVisibleTranslatedReviewIds({});
 	};
 
 	const deleteReview = async (reviewId: number) => {
@@ -329,6 +350,73 @@ const RecipePage = () => {
 		} finally {
 			setDeletingReviewId(null);
 			setReviewIdPendingDelete(null);
+		}
+	};
+
+	const translateReview = async (reviewId: number) => {
+		if (!id || translatingReviewId !== null) {
+			return;
+		}
+
+		const currentTranslation = translatedReviewBodies[reviewId];
+		if (currentTranslation?.language === language) {
+			setVisibleTranslatedReviewIds((current) => ({
+				...current,
+				[reviewId]: !current[reviewId],
+			}));
+			return;
+		}
+
+		setReviewActionError("");
+		setTranslatingReviewId(reviewId);
+
+		try {
+			const response = await fetch(
+				`${API_BASE_URL}/recipes/${id}/reviews/${reviewId}/translate`,
+				{
+					method: "POST",
+					headers: {
+						"X-Language": language,
+					},
+					credentials: "include",
+				},
+			);
+
+			if (!response.ok) {
+				setReviewActionError(
+					t("recipePage.translateReviewError", { status: response.status }),
+				);
+				return;
+			}
+
+			const body: unknown = await response.json();
+			const parsed = ReviewTranslationResponseSchema.safeParse(body);
+
+			if (!parsed.success) {
+				setReviewActionError(
+					t("recipePage.translateReviewError", { status: "unknown" }),
+				);
+				return;
+			}
+
+			setTranslatedReviewBodies((current) => ({
+				...current,
+				[parsed.data.data.review_id]: {
+					body: parsed.data.data.translated_body,
+					language,
+				},
+			}));
+			setVisibleTranslatedReviewIds((current) => ({
+				...current,
+				[parsed.data.data.review_id]: true,
+			}));
+		} catch (error) {
+			console.error(error);
+			setReviewActionError(
+				t("recipePage.translateReviewError", { status: "unknown" }),
+			);
+		} finally {
+			setTranslatingReviewId(null);
 		}
 	};
 
@@ -415,6 +503,8 @@ const RecipePage = () => {
 			.then(({ errorStatus, reviews }) => {
 				setReviewsErrorStatus(errorStatus);
 				setReviews(reviews);
+				setTranslatedReviewBodies({});
+				setVisibleTranslatedReviewIds({});
 			})
 			.finally(() => {
 				setAreReviewsLoading(false);
@@ -637,6 +727,16 @@ const RecipePage = () => {
 									const canDeleteReview =
 										currentUserId !== null &&
 										review.author_id === currentUserId;
+									const translatedReview = translatedReviewBodies[review.id];
+									const isReviewTranslated =
+										translatedReview?.language === language &&
+										visibleTranslatedReviewIds[review.id] === true;
+									const isReviewTranslating = translatingReviewId === review.id;
+									const canTranslateReview =
+										review.source_language !== language;
+									const reviewBody = isReviewTranslated
+										? (translatedReview?.body ?? review.body)
+										: review.body;
 
 									return (
 										<li key={review.id} className="recipe-page-review-card">
@@ -654,7 +754,7 @@ const RecipePage = () => {
 												</div>
 											</div>
 											<div className="recipe-page-review-body">
-												<p className="text-body3">{review.body}</p>
+												<p className="text-body3">{reviewBody}</p>
 												<div className="recipe-page-review-action">
 													{canDeleteReview ? (
 														<IconButton
@@ -670,6 +770,24 @@ const RecipePage = () => {
 													) : null}
 												</div>
 											</div>
+											{canTranslateReview ? (
+												<div className="recipe-page-review-translate-row">
+													<TextIconButton
+														size="body3"
+														className="recipe-page-review-translate"
+														disabled={isReviewTranslating}
+														selected={isReviewTranslated}
+														onClick={() => translateReview(review.id)}
+													>
+														<Translate aria-hidden="true" />
+														{isReviewTranslating
+															? t("recipePage.translatingReview")
+															: isReviewTranslated
+																? t("recipePage.showOriginalReview")
+																: t("recipePage.translateReview")}
+													</TextIconButton>
+												</div>
+											) : null}
 										</li>
 									);
 								})}


### PR DESCRIPTION
## Backend
- Store review source language from `X-Source-Language`
- Add on-demand review translation endpoint
- Expose `source_language` in review responses

## Frontend
- Add Translate / Show original under reviews
- Hide Translate for reviews already in the current site language
- Keep translated text temporarily in React state so toggling between Translate/Show original does not call translation again; original `review.body` is unchanged

close #296 