### PR TITLE
Search improvement

### DIFF
--- a/backend/services/auth-service/src/authGetSet.ts
+++ b/backend/services/auth-service/src/authGetSet.ts
@@ -44,11 +44,15 @@ authGetSet.delete(
 					body: JSON.stringify({ id: userId }),
 				});
 				if (!fetchRes.ok) {
-					console.error(`Core delete of user ${userId} failed with status ${fetchRes.status}`);
+					console.error(
+						`Core delete of user ${userId} failed with status ${fetchRes.status}`,
+					);
 				}
-
 			} catch (error) {
-				console.error(`Failed to delete core profile for user ${userId}:`, error);
+				console.error(
+					`Failed to delete core profile for user ${userId}:`,
+					error,
+				);
 			}
 
 			res.json({ message: "User deleted" });
@@ -168,17 +172,14 @@ authGetSet.post(
 		3. If missing or invalid token → return { authenticated: false }
 	Always returns 200 — safe to call for guests.
 */
-authGetSet.get(
-	"/session",
-	(req: Request, res: Response) => {
-		const decodedToken = help.fetchDecodeToken(req);
-		if (!decodedToken) {
-			res.status(200).json({ authenticated: false });
-			return;
-		}
-		res.status(200).json({ authenticated: true });
-	},
-);
+authGetSet.get("/session", (req: Request, res: Response) => {
+	const decodedToken = help.fetchDecodeToken(req);
+	if (!decodedToken) {
+		res.status(200).json({ authenticated: false });
+		return;
+	}
+	res.status(200).json({ authenticated: true });
+});
 
 /*
 	Fetch user details endpoint

--- a/backend/services/core-service/src/__tests__/users.test.ts
+++ b/backend/services/core-service/src/__tests__/users.test.ts
@@ -79,9 +79,11 @@ describe("Users Routes", () => {
 
 			expect(response.status).toBe(200);
 			expect(response.body).toHaveProperty("data");
-			expect(response.body).toHaveProperty("count");
+			expect(response.body).toHaveProperty("total_count");
+			expect(response.body).toHaveProperty("total_pages");
+			expect(response.body).toHaveProperty("page");
+			expect(response.body).toHaveProperty("per_page");
 			expect(Array.isArray(response.body.data)).toBe(true);
-			expect(response.body.count).toBe(response.body.data.length);
 			if (response.body.data.length > 0) {
 				expect(response.body.data[0]).toHaveProperty("id");
 				expect(response.body.data[0]).toHaveProperty("username");
@@ -97,7 +99,7 @@ describe("Users Routes", () => {
 
 			expect(response.status).toBe(200);
 			expect(response.body).toHaveProperty("data");
-			expect(response.body).toHaveProperty("count", 1);
+			expect(response.body).toHaveProperty("total_count", 1);
 			expect(response.body.data).toHaveLength(1);
 			expect(response.body.data[0]).toHaveProperty("username", "search_cap_01");
 			expect(response.body.data[0]).not.toHaveProperty("status");
@@ -105,11 +107,10 @@ describe("Users Routes", () => {
 		});
 
 		it("should search users case-insensitively and cap results to 20", async () => {
-			const response = await request(app).get("/users?q=SEARCH_CAP_");
+			const response = await request(app).get("/users?q=SEARCH_CAP_&limit=20");
 
 			expect(response.status).toBe(200);
 			expect(response.body).toHaveProperty("data");
-			expect(response.body).toHaveProperty("count", 20);
 			expect(response.body.data).toHaveLength(20);
 			expect(
 				response.body.data.every((user: { username: string }) =>
@@ -124,7 +125,9 @@ describe("Users Routes", () => {
 			);
 
 			expect(response.status).toBe(200);
-			expect(response.body).toEqual({ data: [], count: 0 });
+			expect(response.body).toHaveProperty("data");
+			expect(response.body.data).toHaveLength(0);
+			expect(response.body).toHaveProperty("total_count", 0);
 		});
 
 		it("should return 400 when the search query is too long", async () => {

--- a/backend/services/core-service/src/routes/internalSearch.routes.ts
+++ b/backend/services/core-service/src/routes/internalSearch.routes.ts
@@ -55,5 +55,5 @@ const getSearchRecipeByIdHandler = async (
 	}
 };
 
-internalSearchRouter.get("/recipes/:id", getSearchRecipeByIdHandler);
 internalSearchRouter.get("/recipes", getSearchRecipesHandler);
+internalSearchRouter.get("/recipes/:id", getSearchRecipeByIdHandler);

--- a/backend/services/core-service/src/routes/users.routes.ts
+++ b/backend/services/core-service/src/routes/users.routes.ts
@@ -24,7 +24,10 @@ import {
 	unfollowUser,
 } from "../services/users.service.js";
 import { resolveRequestedLocale } from "../utils/locale.js";
-import { validateUserId } from "../validation/schemas.js";
+import {
+	validatePaginationQuery,
+	validateUserId,
+} from "../validation/schemas.js";
 
 interface CustomError extends Error {
 	statusCode?: number;
@@ -56,8 +59,23 @@ const getAllUsersHandler = async (
 			throw error;
 		}
 
-		const users = await getAllUsers(search || undefined);
-		res.status(200).json({ data: users, count: users.length });
+		const paginationInput = req.query.limit
+			? { ...req.query, per_page: req.query.limit }
+			: req.query;
+
+		const pagination = validatePaginationQuery(paginationInput);
+		if (!pagination.valid) {
+			const error: CustomError = new Error(pagination.error);
+			error.statusCode = 400;
+			throw error;
+		}
+
+		const result = await getAllUsers(
+			pagination.value.page,
+			pagination.value.per_page,
+			search || undefined,
+		);
+		res.status(200).json(result);
 	} catch (error) {
 		next(error);
 	}

--- a/backend/services/core-service/src/routes/users.routes.ts
+++ b/backend/services/core-service/src/routes/users.routes.ts
@@ -70,10 +70,13 @@ const getAllUsersHandler = async (
 			throw error;
 		}
 
+		const sort = typeof req.query.sort === "string" ? req.query.sort : undefined;
+
 		const result = await getAllUsers(
 			pagination.value.page,
 			pagination.value.per_page,
 			search || undefined,
+			sort,
 		);
 		res.status(200).json(result);
 	} catch (error) {

--- a/backend/services/core-service/src/routes/users.routes.ts
+++ b/backend/services/core-service/src/routes/users.routes.ts
@@ -70,7 +70,8 @@ const getAllUsersHandler = async (
 			throw error;
 		}
 
-		const sort = typeof req.query.sort === "string" ? req.query.sort : undefined;
+		const sort =
+			typeof req.query.sort === "string" ? req.query.sort : undefined;
 
 		const result = await getAllUsers(
 			pagination.value.page,

--- a/backend/services/core-service/src/services/recipes.service.ts
+++ b/backend/services/core-service/src/services/recipes.service.ts
@@ -500,9 +500,9 @@ export const getAllRecipesPaginated = async (
 							LIMIT 1
 						) AS picture_url
 					FROM searchable_recipes
-					WHERE search_vector @@ websearch_to_tsquery('simple', $4)
+					WHERE search_vector @@ to_tsquery('simple', regexp_replace(regexp_replace(trim($4), '[^[:alnum:][:space:]]', '', 'g'), '\s+', ':* & ', 'g') || ':*')
 					ORDER BY
-						ts_rank(search_vector, websearch_to_tsquery('simple', $4)) DESC,
+						ts_rank(search_vector, to_tsquery('simple', regexp_replace(regexp_replace(trim($4), '[^[:alnum:][:space:]]', '', 'g'), '\s+', ':* & ', 'g') || ':*')) DESC,
 						created_at DESC,
 						id DESC
 					LIMIT $2 OFFSET $3
@@ -524,7 +524,7 @@ export const getAllRecipesPaginated = async (
 					)
 					SELECT COUNT(*)::int AS total
 					FROM searchable_recipes
-					WHERE search_vector @@ websearch_to_tsquery('simple', $2)
+					WHERE search_vector @@ to_tsquery('simple', regexp_replace(regexp_replace(trim($2), '[^[:alnum:][:space:]]', '', 'g'), '\s+', ':* & ', 'g') || ':*')
 					`,
 					[locale, normalizedSearch],
 				),

--- a/backend/services/core-service/src/services/recipes.service.ts
+++ b/backend/services/core-service/src/services/recipes.service.ts
@@ -500,9 +500,9 @@ export const getAllRecipesPaginated = async (
 							LIMIT 1
 						) AS picture_url
 					FROM searchable_recipes
-					WHERE search_vector @@ to_tsquery('simple', regexp_replace(regexp_replace(trim($4), '[^[:alnum:][:space:]]', '', 'g'), '\s+', ':* & ', 'g') || ':*')
+					WHERE search_vector @@ to_tsquery('simple', regexp_replace(regexp_replace(trim($4), '[^[:alnum:][:space:]]', '', 'g'), 's+', ':* & ', 'g') || ':*')
 					ORDER BY
-						ts_rank(search_vector, to_tsquery('simple', regexp_replace(regexp_replace(trim($4), '[^[:alnum:][:space:]]', '', 'g'), '\s+', ':* & ', 'g') || ':*')) DESC,
+						ts_rank(search_vector, to_tsquery('simple', regexp_replace(regexp_replace(trim($4), '[^[:alnum:][:space:]]', '', 'g'), 's+', ':* & ', 'g') || ':*')) DESC,
 						created_at DESC,
 						id DESC
 					LIMIT $2 OFFSET $3
@@ -524,7 +524,7 @@ export const getAllRecipesPaginated = async (
 					)
 					SELECT COUNT(*)::int AS total
 					FROM searchable_recipes
-					WHERE search_vector @@ to_tsquery('simple', regexp_replace(regexp_replace(trim($2), '[^[:alnum:][:space:]]', '', 'g'), '\s+', ':* & ', 'g') || ':*')
+					WHERE search_vector @@ to_tsquery('simple', regexp_replace(regexp_replace(trim($2), '[^[:alnum:][:space:]]', '', 'g'), 's+', ':* & ', 'g') || ':*')
 					`,
 					[locale, normalizedSearch],
 				),

--- a/backend/services/core-service/src/services/recipes.service.ts
+++ b/backend/services/core-service/src/services/recipes.service.ts
@@ -464,7 +464,10 @@ export const getAllRecipesPaginated = async (
 ): Promise<PaginatedResponse<RecipeListItem>> => {
 	try {
 		const offset = (page - 1) * perPage;
-		const normalizedSearch = search?.trim();
+		// Strip punctuation/symbols that would produce invalid to_tsquery syntax.
+		// If nothing remains after sanitizing (e.g. input was "!!!"), skip search entirely.
+		const normalizedSearch =
+			search?.replace(/[^\p{L}\p{N}\s]/gu, "").trim() || undefined;
 
 		if (normalizedSearch) {
 			const [dataResult, countResult] = await Promise.all([
@@ -500,9 +503,9 @@ export const getAllRecipesPaginated = async (
 							LIMIT 1
 						) AS picture_url
 					FROM searchable_recipes
-					WHERE search_vector @@ to_tsquery('simple', regexp_replace(regexp_replace(trim($4), '[^[:alnum:][:space:]]', '', 'g'), 's+', ':* & ', 'g') || ':*')
+					WHERE search_vector @@ to_tsquery('simple', regexp_replace(trim($4), '[[:space:]]+', ':* & ', 'g') || ':*')
 					ORDER BY
-						ts_rank(search_vector, to_tsquery('simple', regexp_replace(regexp_replace(trim($4), '[^[:alnum:][:space:]]', '', 'g'), 's+', ':* & ', 'g') || ':*')) DESC,
+						ts_rank(search_vector, to_tsquery('simple', regexp_replace(trim($4), '[[:space:]]+', ':* & ', 'g') || ':*')) DESC,
 						created_at DESC,
 						id DESC
 					LIMIT $2 OFFSET $3
@@ -524,7 +527,7 @@ export const getAllRecipesPaginated = async (
 					)
 					SELECT COUNT(*)::int AS total
 					FROM searchable_recipes
-					WHERE search_vector @@ to_tsquery('simple', regexp_replace(regexp_replace(trim($2), '[^[:alnum:][:space:]]', '', 'g'), 's+', ':* & ', 'g') || ':*')
+					WHERE search_vector @@ to_tsquery('simple', regexp_replace(trim($2), '[[:space:]]+', ':* & ', 'g') || ':*')
 					`,
 					[locale, normalizedSearch],
 				),

--- a/backend/services/core-service/src/services/users.service.ts
+++ b/backend/services/core-service/src/services/users.service.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { pool } from "../db/database.js";
 import { areMutualFollowers } from "../utils/service.utils.js";
 import {
+	type PaginatedResponse,
 	type UserListItem,
 	type UserProfile,
 	userListItemSchema,
@@ -66,13 +67,51 @@ const parseUserRows = <T>(
 // ── User queries ──────────────────────────────────────────────────────────────
 
 export const getAllUsers = async (
+	page: number,
+	perPage: number,
 	search?: string,
-): Promise<UserListItem[]> => {
+): Promise<PaginatedResponse<UserListItem>> => {
 	try {
+		const offset = (page - 1) * perPage;
+
 		if (search) {
 			const containsPattern = `%${search}%`;
 			const prefixPattern = `${search}%`;
-			const result = await pool.query(
+
+			const [dataResult, countResult] = await Promise.all([
+				pool.query(
+					`
+					SELECT
+						u.id,
+						u.username,
+						u.avatar,
+						COUNT(r.id)::int AS recipes_count
+					FROM users u
+					LEFT JOIN recipes r ON r.author_id = u.id
+					WHERE u.is_deleted = false AND u.username ILIKE $1
+					GROUP BY u.id, u.username, u.avatar
+					ORDER BY
+						CASE WHEN u.username ILIKE $2 THEN 0 ELSE 1 END,
+						u.username ASC,
+						u.id ASC
+					LIMIT $3 OFFSET $4
+					`,
+					[containsPattern, prefixPattern, perPage, offset],
+				),
+				pool.query(
+					`SELECT COUNT(*)::int AS total FROM users u WHERE u.is_deleted = false AND u.username ILIKE $1`,
+					[containsPattern],
+				),
+			]);
+
+			const total_count = countResult.rows[0].total as number;
+			const total_pages = Math.ceil(total_count / perPage);
+			const data = parseUserRows(dataResult.rows, userListItemSchema, "user");
+			return { data, total_count, total_pages, page, per_page: perPage };
+		}
+
+		const [dataResult, countResult] = await Promise.all([
+			pool.query(
 				`
 				SELECT
 					u.id,
@@ -81,34 +120,22 @@ export const getAllUsers = async (
 					COUNT(r.id)::int AS recipes_count
 				FROM users u
 				LEFT JOIN recipes r ON r.author_id = u.id
-				WHERE u.is_deleted = false AND u.username ILIKE $1
+				WHERE u.is_deleted = false
 				GROUP BY u.id, u.username, u.avatar
-				ORDER BY
-					CASE WHEN u.username ILIKE $2 THEN 0 ELSE 1 END,
-					u.username ASC,
-					u.id ASC
-				LIMIT $3
+				ORDER BY u.id ASC
+				LIMIT $1 OFFSET $2
 				`,
-				[containsPattern, prefixPattern, USER_SEARCH_LIMIT],
-			);
+				[perPage, offset],
+			),
+			pool.query(
+				`SELECT COUNT(*)::int AS total FROM users WHERE is_deleted = false`,
+			),
+		]);
 
-			return parseUserRows(result.rows, userListItemSchema, "user");
-		}
-
-		const result = await pool.query(`
-			SELECT
-				u.id,
-				u.username,
-				u.avatar,
-				COUNT(r.id)::int AS recipes_count
-			FROM users u
-			LEFT JOIN recipes r ON r.author_id = u.id
-			WHERE u.is_deleted = false
-			GROUP BY u.id, u.username, u.avatar
-			ORDER BY u.id ASC
-		`);
-
-		return parseUserRows(result.rows, userListItemSchema, "user");
+		const total_count = countResult.rows[0].total as number;
+		const total_pages = Math.ceil(total_count / perPage);
+		const data = parseUserRows(dataResult.rows, userListItemSchema, "user");
+		return { data, total_count, total_pages, page, per_page: perPage };
 	} catch (error) {
 		console.error("Database error in getAllUsers:", error);
 		throw error;

--- a/backend/services/core-service/src/services/users.service.ts
+++ b/backend/services/core-service/src/services/users.service.ts
@@ -27,7 +27,6 @@ export type FollowOperationResult =
  * Embedded directly in queries — no separate column read needed.
  */
 const IS_ONLINE_SQL = `(u.last_seen_at > now() - interval '60 seconds')`;
-const USER_SEARCH_LIMIT = 20;
 
 const USER_SORT_MAP: Record<string, string> = {
 	"name-asc": "u.username ASC",

--- a/backend/services/core-service/src/services/users.service.ts
+++ b/backend/services/core-service/src/services/users.service.ts
@@ -29,6 +29,13 @@ export type FollowOperationResult =
 const IS_ONLINE_SQL = `(u.last_seen_at > now() - interval '60 seconds')`;
 const USER_SEARCH_LIMIT = 20;
 
+const USER_SORT_MAP: Record<string, string> = {
+	"name-asc": "u.username ASC",
+	"name-desc": "u.username DESC",
+	"recipes-asc": "recipes_count ASC",
+	"recipes-desc": "recipes_count DESC",
+};
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 const doesUserExist = async (userId: number): Promise<boolean> => {
@@ -70,9 +77,11 @@ export const getAllUsers = async (
 	page: number,
 	perPage: number,
 	search?: string,
+	sort?: string,
 ): Promise<PaginatedResponse<UserListItem>> => {
 	try {
 		const offset = (page - 1) * perPage;
+		const sortExpr = USER_SORT_MAP[sort ?? ""] ?? "u.id ASC";
 
 		if (search) {
 			const containsPattern = `%${search}%`;
@@ -92,7 +101,7 @@ export const getAllUsers = async (
 					GROUP BY u.id, u.username, u.avatar
 					ORDER BY
 						CASE WHEN u.username ILIKE $2 THEN 0 ELSE 1 END,
-						u.username ASC,
+						${sortExpr},
 						u.id ASC
 					LIMIT $3 OFFSET $4
 					`,
@@ -122,7 +131,7 @@ export const getAllUsers = async (
 				LEFT JOIN recipes r ON r.author_id = u.id
 				WHERE u.is_deleted = false
 				GROUP BY u.id, u.username, u.avatar
-				ORDER BY u.id ASC
+				ORDER BY ${sortExpr}
 				LIMIT $1 OFFSET $2
 				`,
 				[perPage, offset],


### PR DESCRIPTION
- `/recipes `and `/users` now correctly process query params
- for recipes query could look like:
`q=gt&sort=name-asc&mealType=brunch&dishType=appetizer&mainIngredient=avocado&cuisine=brazilian&limit=12&page=1`
- for users:
`q=gt&sort=name-asc&limit=12&page=1`
- Tests fixed accordingly