### PR TITLE
Fix ingredient fields in recipe create

### DIFF
--- a/frontend/app/assets/styles/recipe-create.css
+++ b/frontend/app/assets/styles/recipe-create.css
@@ -302,14 +302,19 @@
 		flex-shrink: 0;
 	}
 
-	.recipe-ingredient-amount,
-	.recipe-ingredient-unit {
+	.input-field-container.recipe-ingredient-amount {
 		width: 130px;
 		flex-shrink: 0;
 		flex-grow: 0;
 	}
 
-	.recipe-ingredient-name {
+	.select-wrapper.recipe-ingredient-unit {
+		width: 180px;
+		flex-shrink: 0;
+		flex-grow: 0;
+	}
+
+	.select-wrapper.recipe-ingredient-name {
 		flex: 1;
 	}
 


### PR DESCRIPTION
- Make ingredient/unit field sizing target the actual rendered input/select wrapper classes
- Widen the unit select from 130px to 180px! More space to make Yksikkö show in finnish!

## Notes
This prevents shared `SelectField` / `InputField` `width: 100%` styles from overriding the recipe row layout and causing the fields to stretch incorrectly