### PR TITLE
Search remove

### DIFF
--- a/frontend/app/assets/styles/userCard.scss
+++ b/frontend/app/assets/styles/userCard.scss
@@ -54,6 +54,8 @@
 	@include flex-col-center;
 	margin-top: calc(var(--user-card-photo-size) / 2);
 	gap: var(--space-s);
+	width: 100%;
+	min-width: 0;
 
 	h3 {
 		text-align: center;

--- a/frontend/app/routes/recipes.tsx
+++ b/frontend/app/routes/recipes.tsx
@@ -316,24 +316,32 @@ const RecipesPage = () => {
 				}
 			/>
 
-			<SearchField
-				placeholder={t("common.searchPlaceholder")}
-				onSubmit={handleSearch}
-			/>
+			{!isScoped ? (
+				<SearchField
+					placeholder={t("common.searchPlaceholder")}
+					onSubmit={handleSearch}
+				/>
+			) : null}
 
 			{!isScoped && isAuthenticated ? renderTabBar() : null}
 
-			<div className="recipes-page-controls">
-				<SortMenu options={sortOptions} value={sortValue} onChange={setSort} />
-
-				{!isScoped && tab === "all" && (
-					<CategoryFilterMenu
-						categories={categories}
-						values={filterValues}
-						onApply={handleFilterApply}
+			{!isScoped ? (
+				<div className="recipes-page-controls">
+					<SortMenu
+						options={sortOptions}
+						value={sortValue}
+						onChange={setSort}
 					/>
-				)}
-			</div>
+
+					{tab === "all" && (
+						<CategoryFilterMenu
+							categories={categories}
+							values={filterValues}
+							onApply={handleFilterApply}
+						/>
+					)}
+				</div>
+			) : null}
 
 			{mode === "favoritesOf" &&
 			(!isAuthResolved || isMutualFollower === null) ? (


### PR DESCRIPTION
## Summary

- **Hide search/sort/filters on scoped recipe pages** — when viewing another user's recipes (`?userId=`) or favorites (`?favoritesOf=`), the search field, sort menu, and category filter are now hidden. These controls only appear on the global All/My/Saved views where they are functional.
- **Fix username overflow in UserCard** — long usernames were escaping their card container because `.user-card-header` (a centered flex column) shrank to fit its content, making `max-width: 100%` on `h3` meaningless. Adding `width: 100%; min-width: 0` constrains the header to its parent so the ellipsis truncation applies correctly.

## Test plan
- [x] `/recipes?userId=X` — no search, sort, or filter visible
- [x] `/recipes?favoritesOf=X` — same
- [x] `/recipes` (all/my/saved tabs) — search, sort, and filter still present
- [x] Users page with a long username — text truncates with ellipsis inside the card